### PR TITLE
Fix compile error in src/member.cpp

### DIFF
--- a/include/member.hpp
+++ b/include/member.hpp
@@ -6,16 +6,19 @@
 
 namespace hypha
 {
+
+    class dao;
+
     class Member : public Document
     {
     public:
-        Member(const eosio::name contract, const eosio::name &creator, const eosio::name &member);
-        Member(const eosio::name contract, const eosio::checksum256 &hash);
+        Member(dao& dao, const eosio::name &creator, const eosio::name &member);
+        Member(dao& dao, const eosio::checksum256 &hash);
 
-        static Member get (const eosio::name &contract, const eosio::name &member);
+        static Member get (dao& dao, const eosio::name &member);
 
         static const bool isMember(const eosio::name &rootNode, const eosio::name &member);
-        static Member getOrNew (eosio::name contract, const eosio::name &creator, const eosio::name &member);
+        static Member getOrNew (dao& dao, const eosio::name &creator, const eosio::name &member);
         static const eosio::checksum256 calcHash(const eosio::name &member);
 
         eosio::name getAccount ();
@@ -24,6 +27,7 @@ namespace hypha
 
     private: 
         static ContentGroups defaultContent (const eosio::name &member);
+        dao& m_dao;
 
     };
 } // namespace hypha

--- a/src/assignment.cpp
+++ b/src/assignment.cpp
@@ -110,7 +110,7 @@ namespace hypha
 
     Member Assignment::getAssignee()
     {
-        return Member(m_dao->get_self(), Edge::get(m_dao->get_self(), getHash(), common::ASSIGNEE_NAME).getToNode());
+        return Member(*m_dao, Edge::get(m_dao->get_self(), getHash(), common::ASSIGNEE_NAME).getToNode());
         // return m;
     }
 

--- a/src/dao.cpp
+++ b/src/dao.cpp
@@ -208,14 +208,14 @@ namespace hypha
    void dao::apply(const eosio::name &applicant, const std::string &content)
    {
       require_auth(applicant);
-      Member member(get_self(), applicant, applicant);
+      Member member(*this, applicant, applicant);
       member.apply(getRoot(get_self()), content);
    }
 
    void dao::enroll(const eosio::name &enroller, const eosio::name &applicant, const std::string &content)
    {
       require_auth(enroller);
-      Member member = Member::get(get_self(), applicant);
+      Member member = Member::get(*this, applicant);
       member.enroll(enroller, content);
    }
 

--- a/src/member.cpp
+++ b/src/member.cpp
@@ -6,22 +6,24 @@
 #include <document_graph/edge.hpp>
 #include <document_graph/util.hpp>
 #include <util.hpp>
+#include <dao.hpp>
+#include <payers/payer.hpp>
 
 namespace hypha
 {
-    Member::Member(const eosio::name contract, const eosio::name &creator, const eosio::name &member)
-        : Document(contract, contract, defaultContent(member))
+    Member::Member(dao& dao, const eosio::name &creator, const eosio::name &member)
+        : Document(dao.get_self(), dao.get_self(), defaultContent(member)), m_dao(dao)
     {
     }
 
-    Member::Member(const eosio::name contract, const eosio::checksum256 &hash)
-        : Document(contract, hash)
+    Member::Member(dao& dao, const eosio::checksum256 &hash)
+        : Document(dao.get_self(), hash), m_dao(dao)
     {
     }
 
-    Member Member::get(const eosio::name &contract, const eosio::name &member)
+    Member Member::get(dao& dao, const eosio::name &member)
     {
-        return Member(contract, Member::calcHash(member));
+        return Member(dao, Member::calcHash(member));
     }
 
     ContentGroups Member::defaultContent(const eosio::name &member)

--- a/src/migration.cpp
+++ b/src/migration.cpp
@@ -83,7 +83,7 @@ namespace hypha
         eosio::require_auth(m_dao->get_self());
 
         // create the member document
-        hypha::Member member(m_dao->get_self(), m_dao->get_self(), memberName);
+        hypha::Member member(*m_dao, m_dao->get_self(), memberName);
         eosio::checksum256 root = getRoot(m_dao->get_self());
 
         // create the new member edges
@@ -187,7 +187,7 @@ namespace hypha
 
         Document roleDocument(m_dao->get_self(), m_dao->get_self(), role);
 
-        auto owner = hypha::Member::get(m_dao->get_self(), o_itr->names.at("owner"));
+        auto owner = hypha::Member::get(*m_dao, o_itr->names.at("owner"));
 
         // document owner
         eosio::checksum256 ownerHash = getAccountHash(o_itr->names.at("owner"));
@@ -472,7 +472,7 @@ namespace hypha
         eosio::check(a_itr != a_t.end(), "applicant not in applicants table: " + applicant.to_string());
 
         // create the member document
-        hypha::Member member(m_dao->get_self(), m_dao->get_self(), applicant);
+        hypha::Member member(*m_dao, m_dao->get_self(), applicant);
         eosio::checksum256 root = getRoot(m_dao->get_self());
 
         member.apply(root, a_itr->content);


### PR DESCRIPTION
 - It doesn't have m_dao

The errors were:
```
[ 13%] Building CXX object CMakeFiles/dao.dir/member.obj
dao-contracts/src/member.cpp:88:19: error: use 'template' keyword to treat 'getSettingOrFail' as a dependent template name
            m_dao.getSettingOrFail<eosio::name>(TELOS_DECIDE_CONTRACT), eosio::name("mint"),
                  ^
                  template 
dao-contracts/src/member.cpp:88:13: error: use of undeclared identifier 'm_dao'
            m_dao.getSettingOrFail<eosio::name>(TELOS_DECIDE_CONTRACT), eosio::name("mint"),
            ^
dao-contracts/src/member.cpp:92:63: error: use of undeclared identifier 'Payer'
        Document paymentReceipt(getContract(), getContract(), Payer::defaultReceipt(getAccount(), genesis_voice, memo));

```