### PR TITLE
Added approval time check on assignments

### DIFF
--- a/dao-go/assignments_test.go
+++ b/dao-go/assignments_test.go
@@ -17,7 +17,7 @@ func GetAdjustInfo(assignment eos.Checksum256, timeShare int64, startDate eos.Ti
 	return []docgraph.ContentGroup{
 		{
 			{
-				Label: "assignemnt_id",
+				Label: "assignment",
 				Value: &docgraph.FlexValue{
 					BaseVariant: eos.BaseVariant{
 						TypeID: docgraph.GetVariants().TypeID("checksum256"),
@@ -302,9 +302,9 @@ func TestAdjustCommitment(t *testing.T) {
       
       {
         //Period Duration
-				half := periodDuration / 2
-        firstHalf := float32(half/periodDuration)
-        secondHalf := float32((periodDuration-half) / periodDuration)
+				half := int64(periodDuration) / 2
+        firstHalf := float32(half)/periodDuration
+        secondHalf := (periodDuration-float32(half)) / periodDuration
         newTotalSEEDS := totalSEEDS * firstHalf + totalSEEDS * float32(0.5) * secondHalf
         newTotalHYPHA := totalHYPHA * firstHalf + totalHYPHA * float32(0.5) * secondHalf
         newTotalHVOICE := totalHVOICE * firstHalf + totalHVOICE * float32(0.5) * secondHalf

--- a/dao-go/assignments_test.go
+++ b/dao-go/assignments_test.go
@@ -70,9 +70,9 @@ func CreateAdjustmentAfter(commitment, startSecs int64, offsetSecs time.Duration
 	assert.NilError(t, err)
 	assert.Equal(t, ts.String(), strconv.FormatInt(commitment, 10))
 
-  sd, err := timeShare.GetContent("start_date")
-  assert.NilError(t, err);
-  assert.Equal(t, sd.Impl.(eos.TimePoint) / 1000, adjustStartDate / 1000)
+	sd, err := timeShare.GetContent("start_date")
+	assert.NilError(t, err)
+	assert.Equal(t, sd.Impl.(eos.TimePoint)/1000, adjustStartDate/1000)
 
 	return err
 }
@@ -127,210 +127,212 @@ func ValidateLastReceipt(targetHUSD, targetHYPHA, targetHVOICE, targetSEEDS int6
 }
 
 func TestAdjustCommitment(t *testing.T) {
-  teardownTestCase := setupTestCase(t)
-  defer teardownTestCase(t)
+	teardownTestCase := setupTestCase(t)
+	defer teardownTestCase(t)
 
-  env = SetupEnvironment(t)
-  t.Log(env.String())
-  t.Log("\nDAO Environment Setup complete\n")
+	env = SetupEnvironment(t)
+	t.Log(env.String())
+	t.Log("\nDAO Environment Setup complete\n")
 
-  // roles
-  proposer := env.Members[0]
-  assignee := env.Members[1]
-  closer := env.Members[2]
+	// roles
+	proposer := env.Members[0]
+	assignee := env.Members[1]
+	closer := env.Members[2]
 
-  role1Doc := CreateRole(t, env, proposer, closer, role1)
-  t.Run("Test Adjust assignment commitment", func(t *testing.T) {
+	role1Doc := CreateRole(t, env, proposer, closer, role1)
 
-    tests := []struct {
-      name       string
-      roleTitle  string
-      title      string
-      role       docgraph.Document
-      assignment string
-      husd       string
-      hypha      string
-      hvoice     string
-      usd        string
-    }{
-      {
-        name:       "role1 - 100% 100%",
-        roleTitle:  "Underwater Basketweaver",
-        title:      "Underwater Basketweaver - Atlantic",
-        role:       role1Doc,
-        assignment: assignment1,
-        husd:       "0.00 HUSD",
-        hypha:      "759.75 HYPHA",
-        hvoice:     "6078.02 HVOICE",
-        usd:        "3039.01 USD",
-      },
-    }
+	t.Run("Test Adjust assignment commitment", func(t *testing.T) {
 
-    for _, test := range tests {
+		tests := []struct {
+			name       string
+			roleTitle  string
+			title      string
+			role       docgraph.Document
+			assignment string
+			husd       string
+			hypha      string
+			hvoice     string
+			usd        string
+		}{
+			{
+				name:       "role1 - 100% 100%",
+				roleTitle:  "Underwater Basketweaver",
+				title:      "Underwater Basketweaver - Atlantic",
+				role:       role1Doc,
+				assignment: assignment1,
+				husd:       "0.00 HUSD",
+				hypha:      "759.75 HYPHA",
+				hvoice:     "6078.02 HVOICE",
+				usd:        "3039.01 USD",
+			},
+		}
 
-      t.Log("\n\nStarting test: ", test.name)
+		for _, test := range tests {
 
-      _, err := dao.ProposeAssignment(env.ctx, &env.api, env.DAO, proposer.Member, assignee.Member, test.role.Hash, env.Periods[0].Hash, test.assignment)
-      assert.NilError(t, err)
+			t.Log("\n\nStarting test: ", test.name)
 
-      // retrieve the document we just created
-      proposal, err := docgraph.GetLastDocumentOfEdge(env.ctx, &env.api, env.DAO, eos.Name("proposal"))
-      assert.NilError(t, err)
+			_, err := dao.ProposeAssignment(env.ctx, &env.api, env.DAO, proposer.Member, assignee.Member, test.role.Hash, env.Periods[0].Hash, test.assignment)
+			assert.NilError(t, err)
 
-      voteToPassTD(t, env, proposal)
+			// retrieve the document we just created
+			proposal, err := docgraph.GetLastDocumentOfEdge(env.ctx, &env.api, env.DAO, eos.Name("proposal"))
+			assert.NilError(t, err)
 
-      //Wait Half Period to close the proposal and test the special 
-      //case when approved time overlaps in the first period
-      t.Log("Waiting for a period to lapse...")
-      pause(t, env.PeriodPause / 2, "", "Waiting...")
+			voteToPassTD(t, env, proposal)
 
-      _, err = dao.CloseProposal(env.ctx, &env.api, env.DAO, closer.Member, proposal.Hash)
-      assert.NilError(t, err)
+			//Wait Half Period to close the proposal and test the special
+			//case when approved time overlaps in the first period
+			t.Log("Waiting for a period to lapse...")
+			pause(t, env.PeriodPause/2, "", "Waiting...")
 
-      assignment, err := docgraph.GetLastDocumentOfEdge(env.ctx, &env.api, env.DAO, eos.Name("assignment"))
+			_, err = dao.CloseProposal(env.ctx, &env.api, env.DAO, closer.Member, proposal.Hash)
+			assert.NilError(t, err)
+
+			assignment, err := docgraph.GetLastDocumentOfEdge(env.ctx, &env.api, env.DAO, eos.Name("assignment"))
+			assert.NilError(t, err)
 
 			var periodDuration float32
-      var firstPeriodStartSecs int64
-      var firstPeriodEndSecs int64
-      //Get starting period to calculate half period duration
-      {
-        periodHash, err := assignment.GetContent("start_period")
-        assert.NilError(t, err)
-        period, err := docgraph.LoadDocument(env.ctx, &env.api, env.DAO, periodHash.String());
-        assert.NilError(t, err)
-        startTime, err := period.GetContent("start_time")
-        assert.NilError(t, err)
-        firstPeriodStartSecs = int64(startTime.Impl.(eos.TimePoint))/1000000
-        nextPeriods, err := docgraph.GetEdgesFromDocumentWithEdge(env.ctx, &env.api, env.DAO, period, eos.Name("next"))
-        assert.NilError(t, err)
-        nextPeriod, err := docgraph.LoadDocument(env.ctx, &env.api, env.DAO, nextPeriods[0].ToNode.String())
-        assert.NilError(t, err)
-        startTime, err = nextPeriod.GetContent("start_time")
-        assert.NilError(t, err)
-        firstPeriodEndSecs = int64(startTime.Impl.(eos.TimePoint))/1000000
-      }
+			var firstPeriodStartSecs int64
+			var firstPeriodEndSecs int64
+			//Get starting period to calculate half period duration
+			{
+				periodHash, err := assignment.GetContent("start_period")
+				assert.NilError(t, err)
+				period, err := docgraph.LoadDocument(env.ctx, &env.api, env.DAO, periodHash.String())
+				assert.NilError(t, err)
+				startTime, err := period.GetContent("start_time")
+				assert.NilError(t, err)
+				firstPeriodStartSecs = int64(startTime.Impl.(eos.TimePoint)) / 1000000
+				nextPeriods, err := docgraph.GetEdgesFromDocumentWithEdge(env.ctx, &env.api, env.DAO, period, eos.Name("next"))
+				assert.NilError(t, err)
+				nextPeriod, err := docgraph.LoadDocument(env.ctx, &env.api, env.DAO, nextPeriods[0].ToNode.String())
+				assert.NilError(t, err)
+				startTime, err = nextPeriod.GetContent("start_time")
+				assert.NilError(t, err)
+				firstPeriodEndSecs = int64(startTime.Impl.(eos.TimePoint)) / 1000000
+			}
 
-      //Create Adjustment 2.5 Periods after start period
-      CreateAdjustmentAfter(int64(50), firstPeriodStartSecs, 
-                            env.PeriodDuration * 5 / 2,
-                            &assignment,
-                            &assignee, env, t)
+			//Create Adjustment 2.5 Periods after start period
+			CreateAdjustmentAfter(int64(50), firstPeriodStartSecs,
+				env.PeriodDuration*5/2,
+				&assignment,
+				&assignee, env, t)
 
-      //Create Adjustment 3.33 Periods after start period
-      CreateAdjustmentAfter(int64(100), 
-                            firstPeriodStartSecs,
-                            env.PeriodDuration * 10 / 3,
-                            &assignment,
-                            &assignee, env, t)
+			//Create Adjustment 3.33 Periods after start period
+			CreateAdjustmentAfter(int64(100),
+				firstPeriodStartSecs,
+				env.PeriodDuration*10/3,
+				&assignment,
+				&assignee, env, t)
 
-      //Create Adjustment 3.66 Periods after start period
-      CreateAdjustmentAfter(int64(75), 
-                            firstPeriodStartSecs,
-                            env.PeriodDuration * 11 / 3,
-                            &assignment,
-                            &assignee, env, t)
+			//Create Adjustment 3.66 Periods after start period
+			CreateAdjustmentAfter(int64(75),
+				firstPeriodStartSecs,
+				env.PeriodDuration*11/3,
+				&assignment,
+				&assignee, env, t)
 
-      //TODO: Calculate seeds_per_usd using tlosto.seeds table
-      //Set to 0 to temporaly disable  calculating SEEDS
-      hardcodedSeedsPerUsd := float32(0) /*float32(39.0840)*/
-      var seedsDeferralFactor float32
-      {
-        settings, err := docgraph.GetLastDocumentOfEdge(env.ctx, &env.api, env.DAO, eos.Name("settings"))
-        
-        seedsDeferral, err := settings.GetContent("seeds_deferral_factor_x100")
-        assert.NilError(t, err)
+			//TODO: Calculate seeds_per_usd using tlosto.seeds table
+			//Set to 0 to temporaly disable  calculating SEEDS
+			hardcodedSeedsPerUsd := float32(0) /*float32(39.0840)*/
+			var seedsDeferralFactor float32
+			{
+				settings, err := docgraph.GetLastDocumentOfEdge(env.ctx, &env.api, env.DAO, eos.Name("settings"))
 
-        seedsDeferralFactor = float32(seedsDeferral.Impl.(int64)) / 100.0
-      }
+				seedsDeferral, err := settings.GetContent("seeds_deferral_factor_x100")
+				assert.NilError(t, err)
 
-      usdSalaryPerPhase := float32(3039.01)
+				seedsDeferralFactor = float32(seedsDeferral.Impl.(int64)) / 100.0
+			}
 
-      //Number of HYPHA tokens received in 1 full period
-      totalHYPHA := float32(759.75)
+			usdSalaryPerPhase := float32(3039.01)
 
-      //Number of HUSD tokens received in 1 full period
-      totalHUSD := float32(0)
+			//Number of HYPHA tokens received in 1 full period
+			totalHYPHA := float32(759.75)
 
-      //Number of HVOICE tokens received in 1 full period
-      totalHVOICE := float32(usdSalaryPerPhase*2.0)
+			//Number of HUSD tokens received in 1 full period
+			totalHUSD := float32(0)
 
-      //Number of seeds received in 1 full period
-      totalSEEDS := usdSalaryPerPhase * hardcodedSeedsPerUsd * seedsDeferralFactor
+			//Number of HVOICE tokens received in 1 full period
+			totalHVOICE := float32(usdSalaryPerPhase * 2.0)
 
-      //Claim first period
-      t.Log("Waiting for a period to lapse...")
-      pause(t, env.PeriodPause, "", "Waiting...")
+			//Number of seeds received in 1 full period
+			totalSEEDS := usdSalaryPerPhase * hardcodedSeedsPerUsd * seedsDeferralFactor
 
-      //This should get partial payment since the approved time should be > than 
-      //the start time of the period
-      _, err = ClaimNextPeriod(t, env, assignee.Member, assignment)
-      assert.NilError(t, err)
+			//Claim first period
+			t.Log("Waiting for a period to lapse...")
+			pause(t, env.PeriodPause, "", "Waiting...")
 
-      {
-        initTimeShare, err := docgraph.GetLastDocumentOfEdge(env.ctx, &env.api, env.DAO, eos.Name("initimeshare"))
-        assert.NilError(t, err)
-        approvedTime, err := initTimeShare.GetContent("start_date")
-        approvedSecs := int64(approvedTime.Impl.(eos.TimePoint))/1000000
-        periodDuration = float32(firstPeriodEndSecs-firstPeriodStartSecs)
-        timeFactor := float32(firstPeriodEndSecs-approvedSecs) / periodDuration
-        ValidateLastReceipt(int64(totalHUSD*timeFactor),
-                            int64(totalHYPHA*timeFactor),
-                            int64(totalHVOICE*timeFactor),
-                            int64(totalSEEDS*timeFactor), env, t)
-      }
+			//This should get partial payment since the approved time should be > than
+			//the start time of the period
+			_, err = ClaimNextPeriod(t, env, assignee.Member, assignment)
+			assert.NilError(t, err)
 
-      //Claim second period
-      t.Log("Waiting for a period to lapse...")
-      pause(t, env.PeriodPause, "", "Waiting...")
-      
-      //This should get full payment since the first 50% adjustment takes
-      //place on the next period
-      _, err = ClaimNextPeriod(t, env, assignee.Member, assignment)
-      assert.NilError(t, err)
+			{
+				initTimeShare, err := docgraph.GetLastDocumentOfEdge(env.ctx, &env.api, env.DAO, eos.Name("initimeshare"))
+				assert.NilError(t, err)
+				approvedTime, err := initTimeShare.GetContent("start_date")
+				approvedSecs := int64(approvedTime.Impl.(eos.TimePoint)) / 1000000
+				periodDuration = float32(firstPeriodEndSecs - firstPeriodStartSecs)
+				timeFactor := float32(firstPeriodEndSecs-approvedSecs) / periodDuration
+				ValidateLastReceipt(int64(totalHUSD*timeFactor),
+					int64(totalHYPHA*timeFactor),
+					int64(totalHVOICE*timeFactor),
+					int64(totalSEEDS*timeFactor), env, t)
+			}
 
-      //Ignore decimal precision.
-      ValidateLastReceipt(int64(totalHUSD), int64(totalHYPHA), int64(totalHVOICE), int64(totalSEEDS), env, t)
+			//Claim second period
+			t.Log("Waiting for a period to lapse...")
+			pause(t, env.PeriodPause, "", "Waiting...")
 
-      //Claim third period
-      t.Log("Waiting for another period to lapse...")
-      pause(t, env.PeriodPause, "", "Waiting...")
+			//This should get full payment since the first 50% adjustment takes
+			//place on the next period
+			_, err = ClaimNextPeriod(t, env, assignee.Member, assignment)
+			assert.NilError(t, err)
 
-      //This should get full payment for the first half of the period 
-      //and then half payment for the last half of the period
-      _, err = ClaimNextPeriod(t, env, assignee.Member, assignment)
-      assert.NilError(t, err)
-      
-      {
-        //Period Duration
+			//Ignore decimal precision.
+			ValidateLastReceipt(int64(totalHUSD), int64(totalHYPHA), int64(totalHVOICE), int64(totalSEEDS), env, t)
+
+			//Claim third period
+			t.Log("Waiting for another period to lapse...")
+			pause(t, env.PeriodPause, "", "Waiting...")
+
+			//This should get full payment for the first half of the period
+			//and then half payment for the last half of the period
+			_, err = ClaimNextPeriod(t, env, assignee.Member, assignment)
+			assert.NilError(t, err)
+
+			{
+				//Period Duration
 				half := int64(periodDuration) / 2
-        firstHalf := float32(half)/periodDuration
-        secondHalf := (periodDuration-float32(half)) / periodDuration
-        newTotalSEEDS := totalSEEDS * firstHalf + totalSEEDS * float32(0.5) * secondHalf
-        newTotalHYPHA := totalHYPHA * firstHalf + totalHYPHA * float32(0.5) * secondHalf
-        newTotalHVOICE := totalHVOICE * firstHalf + totalHVOICE * float32(0.5) * secondHalf
-        newTotalHUSD := totalHUSD * firstHalf + totalHUSD * float32(0.5) * secondHalf
-        ValidateLastReceipt(int64(newTotalHUSD), int64(newTotalHYPHA), int64(newTotalHVOICE), int64(newTotalSEEDS), env, t)
-      }
+				firstHalf := float32(half) / periodDuration
+				secondHalf := (periodDuration - float32(half)) / periodDuration
+				newTotalSEEDS := totalSEEDS*firstHalf + totalSEEDS*float32(0.5)*secondHalf
+				newTotalHYPHA := totalHYPHA*firstHalf + totalHYPHA*float32(0.5)*secondHalf
+				newTotalHVOICE := totalHVOICE*firstHalf + totalHVOICE*float32(0.5)*secondHalf
+				newTotalHUSD := totalHUSD*firstHalf + totalHUSD*float32(0.5)*secondHalf
+				ValidateLastReceipt(int64(newTotalHUSD), int64(newTotalHYPHA), int64(newTotalHVOICE), int64(newTotalSEEDS), env, t)
+			}
 
-      //Claim last period
-      t.Log("Waiting for another period to lapse...")
-      pause(t, env.PeriodPause, "", "Waiting...")
+			//Claim last period
+			t.Log("Waiting for another period to lapse...")
+			pause(t, env.PeriodPause, "", "Waiting...")
 
-      //This should get half payment for the first third,
-      //full payment on the second third &
-      //75% of payment on the last third
-      _, err = ClaimNextPeriod(t, env, assignee.Member, assignment)
-      assert.NilError(t, err)
+			//This should get half payment for the first third,
+			//full payment on the second third &
+			//75% of payment on the last third
+			_, err = ClaimNextPeriod(t, env, assignee.Member, assignment)
+			assert.NilError(t, err)
 
-      {
-        newTotalSEEDS := CalculateTotalCompensation(0.5, 1.0, 0.75, totalSEEDS)
-        newTotalHYPHA := CalculateTotalCompensation(0.5, 1.0, 0.75, totalHYPHA)
-        newTotalHVOICE := CalculateTotalCompensation(0.5, 1.0, 0.75, totalHVOICE)
-        newTotalHUSD := CalculateTotalCompensation(0.5, 1.0, 0.75, totalHUSD)
-        ValidateLastReceipt(int64(newTotalHUSD), int64(newTotalHYPHA), int64(newTotalHVOICE), int64(newTotalSEEDS), env, t)
-      }
-    }
-  })
+			{
+				newTotalSEEDS := CalculateTotalCompensation(0.5, 1.0, 0.75, totalSEEDS)
+				newTotalHYPHA := CalculateTotalCompensation(0.5, 1.0, 0.75, totalHYPHA)
+				newTotalHVOICE := CalculateTotalCompensation(0.5, 1.0, 0.75, totalHVOICE)
+				newTotalHUSD := CalculateTotalCompensation(0.5, 1.0, 0.75, totalHUSD)
+				ValidateLastReceipt(int64(newTotalHUSD), int64(newTotalHYPHA), int64(newTotalHVOICE), int64(newTotalSEEDS), env, t)
+			}
+		}
+	})
 }
 
 func TestAssignmentProposalDocument(t *testing.T) {
@@ -485,6 +487,9 @@ func TestAssignmentProposalDocument(t *testing.T) {
 
 			t.Log("Member: ", closer.Member, " is closing assignment proposal	: ", assignment.Hash.String())
 			_, err = dao.CloseProposal(env.ctx, &env.api, env.DAO, closer.Member, assignment.Hash)
+			assert.NilError(t, err)
+
+			assignment, err = docgraph.GetLastDocumentOfEdge(env.ctx, &env.api, env.DAO, eos.Name("assignment"))
 			assert.NilError(t, err)
 
 			// verify that the edges are created correctly
@@ -668,18 +673,18 @@ func TestOldAssignmentsPayClaim(t *testing.T) {
 			ExecuteDocgraphCall(t, env, func() {
 				//Create edges
 				_, err = docgraph.CreateEdge(env.ctx, &env.api, env.DAO, env.DAO, proposer.Doc.Hash, assignment.Hash, eos.Name("assigned"))
-		
+
 				assert.NilError(t, err)
-		
+
 				_, err = docgraph.CreateEdge(env.ctx, &env.api, env.DAO, env.DAO, assignment.Hash, proposer.Doc.Hash, eos.Name("assignee"))
-		
+
 				assert.NilError(t, err)
-		
+
 				_, err = docgraph.CreateEdge(env.ctx, &env.api, env.DAO, env.DAO, role.Hash, assignment.Hash, eos.Name("assignment"))
-		
+
 				assert.NilError(t, err)
-			})			
-			
+			})
+
 			fv, err := assignment.GetContent("title")
 			assert.NilError(t, err)
 			assert.Equal(t, fv.String(), test.title)
@@ -705,17 +710,22 @@ func TestOldAssignmentsPayClaim(t *testing.T) {
 			_, err = ClaimNextPeriod(t, env, proposer.Member, assignment)
 			assert.NilError(t, err)
 
+			// Assignment hash will change due origina_approved_date item begin added the first time
+			// we claim with an old assignment
+			assignment, err = docgraph.GetLastDocumentOfEdge(env.ctx, &env.api, env.DAO, eos.Name("assignment"))
+			assert.NilError(t, err)
+
 			fetchedAssignment, err := docgraph.GetLastDocumentOfEdge(env.ctx, &env.api, env.DAO, eos.Name("assignment"))
 
 			husd, err := fetchedAssignment.GetContent("husd_salary_per_phase")
 			assert.NilError(t, err)
-
 			hypha, err := fetchedAssignment.GetContent("hypha_salary_per_phase")
+
 			assert.NilError(t, err)
 
 			hvoice, err := fetchedAssignment.GetContent("hvoice_salary_per_phase")
 			assert.NilError(t, err)
-			
+
 			var payments []Balance
 			// first payment is a partial payment, so should be less than the amount on the assignment record
 			payments = append(payments, CalcLastPayment(t, env, balances[len(balances)-1], proposer.Member))
@@ -955,6 +965,13 @@ func TestAssignmentExtensionProposal(t *testing.T) {
 
 			t.Log("Member: ", closer.Member, " is closing assignment proposal	: ", assignment.Hash.String())
 			_, err = dao.CloseProposal(env.ctx, &env.api, env.DAO, closer.Member, assignment.Hash)
+			assert.NilError(t, err)
+
+			pause(t, 1000000000, "", "Waiting before fetching assignment again")
+
+			// Assignment hash will change due origina_approved_date item begin added the first time
+			// we claim with an old assignment
+			assignment, err = docgraph.GetLastDocumentOfEdge(env.ctx, &env.api, env.DAO, eos.Name("assignment"))
 			assert.NilError(t, err)
 
 			// verify that the edges are created correctly

--- a/dao-go/environment_test.go
+++ b/dao-go/environment_test.go
@@ -154,7 +154,7 @@ func SetupEnvironmentWithFlags(t *testing.T, addFakePeriods, addFakeMembers bool
 	env.SeedsDeferralFactor = 100
 	env.HyphaDeferralFactor = 25
 
-	env.PeriodDuration, _ = time.ParseDuration("5s")
+	env.PeriodDuration, _ = time.ParseDuration("10s")
 	env.NumPeriods = 20
 
 	// pauses

--- a/dao-go/helpers_test.go
+++ b/dao-go/helpers_test.go
@@ -132,7 +132,7 @@ func ClaimNextPeriod(t *testing.T, env *Environment, claimer eos.AccountName, as
 }
 
 type AdjustData struct {
-	Issuer eos.AccountName `json:"issuer"`
+	Issuer     eos.AccountName         `json:"issuer"`
 	AdjustInfo []docgraph.ContentGroup `json:"adjust_info"`
 }
 
@@ -145,12 +145,12 @@ func AdjustCommitment(env *Environment, assignee eos.AccountName, adjustInfo []d
 			{Actor: assignee, Permission: eos.PN("active")},
 		},
 		ActionData: eos.NewActionData(AdjustData{
-			Issuer: assignee,
+			Issuer:     assignee,
 			AdjustInfo: adjustInfo,
 		}),
 	}}
 
-	return eostest.ExecTrx(env.ctx, &env.api, actions);
+	return eostest.ExecTrx(env.ctx, &env.api, actions)
 }
 
 func pause(t *testing.T, seconds time.Duration, headline, prefix string) {
@@ -208,6 +208,10 @@ func CreateAssignment(t *testing.T, env *Environment, role *docgraph.Document,
 	_, err = dao.CloseProposal(env.ctx, &env.api, env.DAO, closer.Member, assignment.Hash)
 	assert.NilError(t, err)
 
+	pause(t, 1000000000, "", "Waiting before fetching role")
+	assignment, err = docgraph.GetLastDocumentOfEdge(env.ctx, &env.api, env.DAO, eos.Name("assignment"))
+	assert.NilError(t, err)
+	assert.Equal(t, assignment.Creator, proposer.Member)
 	// verify that the edges are created correctly
 	// Graph structure post creating proposal:
 	// update graph edges:
@@ -253,6 +257,12 @@ func CreateRole(t *testing.T, env *Environment, proposer, closer Member, content
 	t.Log("Member: ", closer.Member, " is closing role proposal	: ", role.Hash.String())
 	_, err = dao.CloseProposal(env.ctx, &env.api, env.DAO, closer.Member, role.Hash)
 	assert.NilError(t, err)
+
+	pause(t, 1000000000, "", "Waiting before fetching role")
+	//Must fetch again since the hash changes on proposal close
+	role, err = docgraph.GetLastDocumentOfEdge(env.ctx, &env.api, env.DAO, eos.Name("role"))
+	assert.NilError(t, err)
+	assert.Equal(t, role.Creator, proposer.Member)
 
 	// verify that the edges are created correctly
 	// Graph structure post creating proposal:
@@ -328,7 +338,7 @@ func checkEdge(t *testing.T, env *Environment, fromEdge, toEdge docgraph.Documen
 }
 
 func checkLastVote(t *testing.T, env *Environment, proposal docgraph.Document, voter Member) docgraph.Document {
-    // Wait 1s - If we don't, some Edges are not found.
+	// Wait 1s - If we don't, some Edges are not found.
 	pause(t, 1000000000, "", "Waiting before fetching last vote")
 	vote, err := docgraph.GetLastDocumentOfEdge(env.ctx, &env.api, env.DAO, eos.Name("vote"))
 	assert.NilError(t, err)

--- a/include/common.hpp
+++ b/include/common.hpp
@@ -49,6 +49,7 @@ namespace common
 
     static constexpr name ASSIGNED = name("assigned");
     static constexpr name ASSIGNEE_NAME = name("assignee");
+    constexpr        auto APPROVED_DATE = "original_approved_date";
     static constexpr name PERIOD = name("period");
     static constexpr name START = name ("start");
     static constexpr name NEXT = name ("next");

--- a/src/assignment.cpp
+++ b/src/assignment.cpp
@@ -116,7 +116,7 @@ namespace hypha
         return getContentWrapper().getOrFail(DETAILS, PERIOD_COUNT)->getAs<int64_t>();
     }
 
-    // TODO: move to proposal class
+    // TODO: move to proposal class (needs some further design)
     eosio::time_point Assignment::getApprovedTime()
     {
         auto cw = getContentWrapper();
@@ -140,11 +140,9 @@ namespace hypha
         else if (auto [hasTimeShare, edge] = Edge::getIfExists(m_dao->get_self(), getHash(), common::INIT_TIME_SHARE);
                  hasTimeShare)
         {
-          auto date = getInitialTimeShare().
-                      getContentWrapper().
-                      getOrFail(DETAILS, TIME_SHARE_START_DATE)->getAs<eosio::time_point>();
-          cw.insertOrReplace(detailsIdx, Content{common::APPROVED_DATE, date});
-          return date;
+          return getInitialTimeShare().
+                 getContentWrapper().
+                 getOrFail(DETAILS, TIME_SHARE_START_DATE)->getAs<eosio::time_point>();
         }
         
         //Fallback for old assignments without time share document

--- a/src/proposals/ass_extend_proposal.cpp
+++ b/src/proposals/ass_extend_proposal.cpp
@@ -1,3 +1,5 @@
+#include <string_view>
+
 #include <eosio/asset.hpp>
 #include <eosio/crypto.hpp>
 
@@ -35,6 +37,7 @@ namespace hypha
         // confirm that the original document exists
         Document original (m_dao.get_self(), proposalContent.getOrFail(DETAILS, ORIGINAL_DOCUMENT)->getAs<eosio::checksum256>());
 
+        //TODO: This edge has to cleaned up when proposal fails
         // connect the edit proposal to the original
         Edge::write (m_dao.get_self(), m_dao.get_self(), proposal.getHash(), original.getHash(), common::ORIGINAL);
         eosio::print("writing edge from proposal to original. proposal: " + readableHash(proposal.getHash()) + "\n");
@@ -47,8 +50,49 @@ namespace hypha
         // merge the original with the edits and save
         ContentWrapper proposalContent = proposal.getContentWrapper();
 
+        auto [detailsIdx, details] = proposalContent.getGroup(DETAILS);
+
+        //Save a copy of original details
+        auto originalContents = proposal.getContentGroups();
+
+        auto skippedGroups = {SYSTEM, BALLOT, BALLOT_OPTIONS};
+
+        for (auto groupLabel : skippedGroups) 
+        {
+          if (auto [groupIdx, group] = proposalContent.getGroup(groupLabel);
+              group != nullptr)
+          {
+            proposalContent.insertOrReplace(groupIdx, 
+                                            Content{"skip_from_merge", 0});
+          }
+        }
+
+        auto ignoredDetailsItems = {TITLE,
+                                    DESCRIPTION,
+                                    ORIGINAL_DOCUMENT, 
+                                    common::APPROVED_DATE};
+
+        for (auto item : ignoredDetailsItems) 
+        {
+          if (auto [_, content] = proposalContent.get(detailsIdx, item);
+              content != nullptr)
+          {
+            proposalContent.removeContent(detailsIdx, item);
+          }
+        }
+        
         // confirm that the original document exists
-        Document original (m_dao.get_self(), proposalContent.getOrFail(DETAILS, ORIGINAL_DOCUMENT)->getAs<eosio::checksum256>());
+        // Use the ORIGINAL edge since the original document could have changed since this was 
+        // proposed
+        //Document original (m_dao.get_self(), proposalContent.getOrFail(DETAILS, ORIGINAL_DOCUMENT)->getAs<eosio::checksum256>());
+        auto edges = m_dao.getGraph().getEdgesFrom(proposal.getHash(), common::ORIGINAL);
+        
+        eosio::check(
+          edges.size() == 1, 
+          "Missing edge from extension proposal: " + readableHash(proposal.getHash()) + " to original document"
+        );
+
+        Document original (m_dao.get_self(), edges[0].getToNode());
 
         // update all edges to point to the new document
         Document merged = Document::merge(original, proposal);
@@ -59,6 +103,9 @@ namespace hypha
 
         // erase the original document
         m_dao.getGraph().eraseDocument(original.getHash(), true);
+
+        //Restore groups
+        proposalContent.getContentGroups() = std::move(originalContents);
     }
 
     std::string AssignmentExtensionProposal::getBallotContent (ContentWrapper &contentWrapper)

--- a/src/proposals/assignment_proposal.cpp
+++ b/src/proposals/assignment_proposal.cpp
@@ -132,7 +132,10 @@ namespace hypha
         int64_t initTimeShare = contentWrapper.getOrFail(DETAILS, TIME_SHARE)->getAs<int64_t>();
         
         //Set starting date to approval date.
-        TimeShare initTimeShareDoc(m_dao.get_self(), m_dao.get_self(), initTimeShare, eosio::current_time_point());
+        TimeShare initTimeShareDoc(m_dao.get_self(), 
+                                   m_dao.get_self(), 
+                                   initTimeShare, 
+                                   contentWrapper.getOrFail(DETAILS, common::APPROVED_DATE)->getAs<eosio::time_point>());
 
         Edge::write(m_dao.get_self(), m_dao.get_self(), proposal.getHash(), initTimeShareDoc.getHash(), common::INIT_TIME_SHARE);
         Edge::write(m_dao.get_self(), m_dao.get_self(), proposal.getHash(), initTimeShareDoc.getHash(), common::CURRENT_TIME_SHARE);

--- a/src/proposals/proposal.cpp
+++ b/src/proposals/proposal.cpp
@@ -138,9 +138,17 @@ namespace hypha
         
         if (proposalDidPass)
         {
+            auto details = proposal.getContentWrapper().getGroupOrFail(DETAILS);
+            ContentWrapper::insertOrReplace(*details, Content{
+              common::APPROVED_DATE,
+              eosio::current_time_point()
+            });
             // INVOKE child class close logic
             passImpl(proposal);
-            // TODO: add original approval date to system group
+
+            proposal = m_dao.getGraph().updateDocument(proposal.getCreator(), 
+                                                       proposal.getHash(),
+                                                       std::move(proposal.getContentGroups()));
             // if proposal passes, create an edge for PASSED_PROPS
             Edge::write(m_dao.get_self(), m_dao.get_self(), root, proposal.getHash(), common::PASSED_PROPS);
         }


### PR DESCRIPTION
I added an extra check to see if 'original_approved_date' item is present on assignments when checking for the Approval date.

This is the fix we came up with to solve the issue of edited/extended assignments which approval time is wrong since we take into account the edge [proposal] -> [assigned] -> [member] creation date which gets updated whenever there is a modification on the assignment.

The approved date content item gets added when **ANY** proposal is closed & approved.

I also added code to prevent edit & extend proposals from overriding the original assignment data i.e. title & description as well as other content groups (SYSTEM, BALLOT & BALLOT_OPTIONS).