### PR TITLE
Claiming period causes document collision when creating time shares

### DIFF
--- a/include/time_share.hpp
+++ b/include/time_share.hpp
@@ -20,7 +20,7 @@ public:
   /**
   * Inserts a new TimeShare in the Document Graph
   */
-  TimeShare(name contract, name creator, int64_t timeShare, time_point startDate);
+  TimeShare(name contract, name creator, int64_t timeShare, time_point startDate, checksum256 assignment);
 
   /**
   * Loads a TimeShare with the given hash
@@ -30,7 +30,7 @@ public:
   std::optional<TimeShare> getNext(name contract);
 private:
 
-  ContentGroups constructContentGroups(int64_t timeShare, time_point startDate);
+  ContentGroups constructContentGroups(int64_t timeShare, time_point startDate, checksum256 assignment);
 };
 
 }

--- a/src/dao.cpp
+++ b/src/dao.cpp
@@ -110,7 +110,7 @@ namespace hypha
 
          //Set starting date to approval date.
          auto approvedDate = assignment.getApprovedTime();
-         TimeShare initTimeShareDoc(get_self(), get_self(), initTimeShare, approvedDate);
+         TimeShare initTimeShareDoc(get_self(), get_self(), initTimeShare, approvedDate, assignment.getHash());
 
          Edge::write(get_self(), get_self(), assignment.getHash(), initTimeShareDoc.getHash(), common::INIT_TIME_SHARE);
          Edge::write(get_self(), get_self(), assignment.getHash(), initTimeShareDoc.getHash(), common::CURRENT_TIME_SHARE);
@@ -643,7 +643,7 @@ namespace hypha
 
           //Set starting date to approval date.
           auto approvedDate = assignment.getApprovedTime();
-          TimeShare initTimeShareDoc(get_self(), get_self(), initTimeShare, approvedDate);
+          TimeShare initTimeShareDoc(get_self(), get_self(), initTimeShare, approvedDate, assignment.getHash());
 
           Edge::write(get_self(), get_self(), assignment.getHash(), initTimeShareDoc.getHash(), common::INIT_TIME_SHARE);
           Edge::write(get_self(), get_self(), assignment.getHash(), initTimeShareDoc.getHash(), common::CURRENT_TIME_SHARE);
@@ -682,7 +682,7 @@ namespace hypha
                          "New time share start date must be greater than the previous time share");
          }
 
-         TimeShare newTimeShareDoc(get_self(), issuer, newTimeShare, startDate);
+         TimeShare newTimeShareDoc(get_self(), issuer, newTimeShare, startDate, assignment.getHash());
 
          Edge::write(get_self(), get_self(), lastTimeShareEdge.getToNode(), newTimeShareDoc.getHash(), common::NEXT_TIME_SHARE);
 

--- a/src/proposals/assignment_proposal.cpp
+++ b/src/proposals/assignment_proposal.cpp
@@ -135,7 +135,8 @@ namespace hypha
         TimeShare initTimeShareDoc(m_dao.get_self(), 
                                    m_dao.get_self(), 
                                    initTimeShare, 
-                                   contentWrapper.getOrFail(SYSTEM, common::APPROVED_DATE)->getAs<eosio::time_point>());
+                                   contentWrapper.getOrFail(SYSTEM, common::APPROVED_DATE)->getAs<eosio::time_point>(),
+                                   proposal.getHash());
 
         Edge::write(m_dao.get_self(), m_dao.get_self(), proposal.getHash(), initTimeShareDoc.getHash(), common::INIT_TIME_SHARE);
         Edge::write(m_dao.get_self(), m_dao.get_self(), proposal.getHash(), initTimeShareDoc.getHash(), common::CURRENT_TIME_SHARE);

--- a/src/time_share.cpp
+++ b/src/time_share.cpp
@@ -5,8 +5,8 @@
 
 namespace hypha {
 
-TimeShare::TimeShare(name contract, name creator, int64_t timeShare, time_point startDate) 
-: Document(contract, creator, constructContentGroups(timeShare, startDate))
+TimeShare::TimeShare(name contract, name creator, int64_t timeShare, time_point startDate, checksum256 assignment) 
+: Document(contract, creator, constructContentGroups(timeShare, startDate, assignment))
 {
   
 }
@@ -27,13 +27,14 @@ std::optional<TimeShare> TimeShare::getNext(name contract)
   return std::nullopt;
 }
 
-ContentGroups TimeShare::constructContentGroups(int64_t timeShare, time_point startDate) 
+ContentGroups TimeShare::constructContentGroups(int64_t timeShare, time_point startDate, checksum256 assignment) 
 {
   return {
     ContentGroup {
       Content(CONTENT_GROUP_LABEL, DETAILS),
       Content(TIME_SHARE, timeShare),
       Content(TIME_SHARE_START_DATE, startDate),
+      Content(ASSIGNMENT_STRING, assignment)
     },
     ContentGroup {
       Content(CONTENT_GROUP_LABEL, SYSTEM),


### PR DESCRIPTION
Since time share documents only store time_share_x100 and start_date I was assuming the possibility of collision was highly low since it is very unlikely 2 assignments would get approved (closed) at the exact same time. However because we manually introduced 'original_approved_time' on some assignments this was no longer true and some of them have this value repeated (i.e. F4191BA9B99B874BEB1690CFE21939CCCD9F62C9C7BBC82F0924CAAF5F0ADF2B, 39DBF9C128E8ACC6718EC8F0B085436993121A4AE493EC9EC9E24D7074D820F0, EA61E3DE0F14989A83CC078A565781B48FD09F2D406B72743E7A104A2BC9DD7E). So my solution is to add the assignment hash to the time share document so it's now nearly impossible that 2 different assignment's time shares collide.