### PR TITLE
Remove non-needed cmake include that causes a whole rebuild

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,16 +15,3 @@ ExternalProject_Add(
    INSTALL_COMMAND ""
    BUILD_ALWAYS 1
 )
-
-
-ExternalProject_Add(
-   doc_project
-   SOURCE_DIR ${CMAKE_SOURCE_DIR}/document-graph
-   BINARY_DIR ${CMAKE_BINARY_DIR}/doc
-   CMAKE_ARGS -DCMAKE_TOOLCHAIN_FILE=${EOSIO_CDT_ROOT}/lib/cmake/eosio.cdt/EosioWasmToolchain.cmake
-   UPDATE_COMMAND ""
-   PATCH_COMMAND ""
-   TEST_COMMAND ""
-   INSTALL_COMMAND ""
-   BUILD_ALWAYS 1
-)


### PR DESCRIPTION
I have no idea why/how I added this cmake config... but removing now.