### PR TITLE
Withdraw & Suspend actions

### DIFF
--- a/dao-go/assignments_test.go
+++ b/dao-go/assignments_test.go
@@ -14,1148 +14,1477 @@ import (
 
 func GetAdjustInfo(assignment eos.Checksum256, timeShare int64, startDate eos.TimePoint) []docgraph.ContentGroup {
 
-	return []docgraph.ContentGroup{
-		{
-			{
-				Label: "assignment",
-				Value: &docgraph.FlexValue{
-					BaseVariant: eos.BaseVariant{
-						TypeID: docgraph.GetVariants().TypeID("checksum256"),
-						Impl:   assignment,
-					}},
-			},
-			{
-				Label: "new_time_share_x100",
-				Value: &docgraph.FlexValue{
-					BaseVariant: eos.BaseVariant{
-						TypeID: docgraph.GetVariants().TypeID("int64"),
-						Impl:   timeShare,
-					}},
-			},
-			{
-				Label: "start_date",
-				Value: &docgraph.FlexValue{
-					BaseVariant: eos.BaseVariant{
-						TypeID: docgraph.GetVariants().TypeID("time_point"),
-						Impl:   startDate,
-					}},
-			},
-		}}
+  return []docgraph.ContentGroup{
+    {
+      {
+        Label: "assignment",
+        Value: &docgraph.FlexValue{
+          BaseVariant: eos.BaseVariant{
+            TypeID: docgraph.GetVariants().TypeID("checksum256"),
+            Impl:   assignment,
+          }},
+      },
+      {
+        Label: "new_time_share_x100",
+        Value: &docgraph.FlexValue{
+          BaseVariant: eos.BaseVariant{
+            TypeID: docgraph.GetVariants().TypeID("int64"),
+            Impl:   timeShare,
+          }},
+      },
+      {
+        Label: "start_date",
+        Value: &docgraph.FlexValue{
+          BaseVariant: eos.BaseVariant{
+            TypeID: docgraph.GetVariants().TypeID("time_point"),
+            Impl:   startDate,
+          }},
+      },
+    }}
 }
 
 //Used to calculate token compensation with 3 adjustments over the same
 //period
 func CalculateTotalCompensation(alfa, beta, gamma, totalByPeriod float32) float32 {
-	//Or factorized totalByPeriod*1.0/3.0*(alfa+beta+gamma)
-	return totalByPeriod*1.0/3.0*alfa +
-		totalByPeriod*1.0/3.0*beta +
-		totalByPeriod*1.0/3.0*gamma
+  //Or factorized totalByPeriod*1.0/3.0*(alfa+beta+gamma)
+  return totalByPeriod*1.0/3.0*alfa +
+    totalByPeriod*1.0/3.0*beta +
+    totalByPeriod*1.0/3.0*gamma
 }
 
 func CreateAdjustmentAfter(commitment, startSecs int64, offsetSecs time.Duration, assignment *docgraph.Document, assignee *Member, env *Environment, t *testing.T) error {
 
-	time := time.Unix(startSecs, 0)
+  time := time.Unix(startSecs, 0)
 
-	adjustStartDate := eos.TimePoint(time.Add(offsetSecs).UnixNano() / 1000)
+  adjustStartDate := eos.TimePoint(time.Add(offsetSecs).UnixNano() / 1000)
 
-	var adjustInfo = GetAdjustInfo(assignment.Hash, commitment, adjustStartDate)
+  var adjustInfo = GetAdjustInfo(assignment.Hash, commitment, adjustStartDate)
 
-	_, err := AdjustCommitment(env, assignee.Member, adjustInfo)
+  _, err := AdjustCommitment(env, assignee.Member, adjustInfo)
 
-	assert.NilError(t, err)
+  assert.NilError(t, err)
 
-	timeShare, err := docgraph.GetLastDocument(env.ctx, &env.api, env.DAO)
+  timeShare, err := docgraph.GetLastDocument(env.ctx, &env.api, env.DAO)
 
-	ts, err := timeShare.GetContent("time_share_x100")
-	assert.NilError(t, err)
-	assert.Equal(t, ts.String(), strconv.FormatInt(commitment, 10))
+  ts, err := timeShare.GetContent("time_share_x100")
+  assert.NilError(t, err)
+  assert.Equal(t, ts.String(), strconv.FormatInt(commitment, 10))
 
-	sd, err := timeShare.GetContent("start_date")
-	assert.NilError(t, err)
-	assert.Equal(t, sd.Impl.(eos.TimePoint)/1000, adjustStartDate/1000)
+  sd, err := timeShare.GetContent("start_date")
+  assert.NilError(t, err)
+  assert.Equal(t, sd.Impl.(eos.TimePoint)/1000, adjustStartDate/1000)
 
-	return err
+  return err
 }
 
 func AssetToInt(asset *docgraph.FlexValue) (int64, string, error) {
-	assetStr := asset.Impl.(eos.Asset).String()
-	stringItms := strings.Split(assetStr, " ")
-	parsed, err := strconv.ParseFloat(stringItms[0], 32)
+  assetStr := asset.Impl.(eos.Asset).String()
+  stringItms := strings.Split(assetStr, " ")
+  parsed, err := strconv.ParseFloat(stringItms[0], 32)
 
-	return int64(parsed), stringItms[1], err
+  return int64(parsed), stringItms[1], err
 }
 
 func ValidateLastReceipt(targetHUSD, targetHYPHA, targetHVOICE, targetSEEDS int64, env *Environment, t *testing.T) {
 
-	period, err := docgraph.GetLastDocumentOfEdge(env.ctx, &env.api, env.DAO, eos.Name("claimed"))
-	assert.NilError(t, err)
+  period, err := docgraph.GetLastDocumentOfEdge(env.ctx, &env.api, env.DAO, eos.Name("claimed"))
+  assert.NilError(t, err)
 
-	paymentEdges, err := docgraph.GetEdgesFromDocumentWithEdge(env.ctx, &env.api, env.DAO, period, eos.Name("payment"))
-	assert.NilError(t, err)
+  paymentEdges, err := docgraph.GetEdgesFromDocumentWithEdge(env.ctx, &env.api, env.DAO, period, eos.Name("payment"))
+  assert.NilError(t, err)
 
-	var paymentMap map[string]int64
+  var paymentMap map[string]int64
 
-	paymentMap = make(map[string]int64)
+  paymentMap = make(map[string]int64)
 
-	for _, edge := range paymentEdges {
-		payment, err := docgraph.LoadDocument(env.ctx, &env.api, env.DAO, edge.ToNode.String())
-		assert.NilError(t, err)
-		asset, err := payment.GetContent("amount")
-		assert.NilError(t, err)
-		amount, symbol, err := AssetToInt(asset)
-		assert.NilError(t, err)
-		paymentMap[symbol] = amount
-	}
+  for _, edge := range paymentEdges {
+    payment, err := docgraph.LoadDocument(env.ctx, &env.api, env.DAO, edge.ToNode.String())
+    assert.NilError(t, err)
+    asset, err := payment.GetContent("amount")
+    assert.NilError(t, err)
+    amount, symbol, err := AssetToInt(asset)
+    assert.NilError(t, err)
+    paymentMap[symbol] = amount
+  }
 
-	if targetHUSD != 0 {
-		assert.Equal(t, targetHUSD, paymentMap["HUSD"])
-	}
+  if targetHUSD != 0 {
+    assert.Equal(t, targetHUSD, paymentMap["HUSD"])
+  }
 
-	if targetHYPHA != 0 {
-		assert.Equal(t, targetHYPHA, paymentMap["HYPHA"])
-	}
+  if targetHYPHA != 0 {
+    assert.Equal(t, targetHYPHA, paymentMap["HYPHA"])
+  }
 
-	if targetHVOICE != 0 {
-		assert.Equal(t, targetHVOICE, paymentMap["HVOICE"])
-	}
+  if targetHVOICE != 0 {
+    assert.Equal(t, targetHVOICE, paymentMap["HVOICE"])
+  }
 
-	if targetSEEDS != 0 {
-		assert.Equal(t, targetSEEDS, paymentMap["SEEDS"])
-	}
+  if targetSEEDS != 0 {
+    assert.Equal(t, targetSEEDS, paymentMap["SEEDS"])
+  }
 
-	assert.NilError(t, err)
+  assert.NilError(t, err)
 }
 
 func TestAdjustCommitment(t *testing.T) {
-	teardownTestCase := setupTestCase(t)
-	defer teardownTestCase(t)
+  teardownTestCase := setupTestCase(t)
+  defer teardownTestCase(t)
 
-	env = SetupEnvironment(t)
-	t.Log(env.String())
-	t.Log("\nDAO Environment Setup complete\n")
+  env = SetupEnvironment(t)
+  t.Log(env.String())
+  t.Log("\nDAO Environment Setup complete\n")
 
-	// roles
-	proposer := env.Members[0]
-	assignee := env.Members[1]
-	closer := env.Members[2]
+  // roles
+  proposer := env.Members[0]
+  assignee := env.Members[1]
+  closer := env.Members[2]
 
-	role1Doc := CreateRole(t, env, proposer, closer, role1)
+  role1Doc := CreateRole(t, env, proposer, closer, role1)
 
-	t.Run("Test Adjust assignment commitment", func(t *testing.T) {
+  t.Run("Test Adjust assignment commitment", func(t *testing.T) {
 
-		tests := []struct {
-			name       string
-			roleTitle  string
-			title      string
-			role       docgraph.Document
-			assignment string
-			husd       string
-			hypha      string
-			hvoice     string
-			usd        string
-		}{
-			{
-				name:       "role1 - 100% 100%",
-				roleTitle:  "Underwater Basketweaver",
-				title:      "Underwater Basketweaver - Atlantic",
-				role:       role1Doc,
-				assignment: assignment1,
-				husd:       "0.00 HUSD",
-				hypha:      "759.75 HYPHA",
-				hvoice:     "6078.02 HVOICE",
-				usd:        "3039.01 USD",
-			},
-		}
+    tests := []struct {
+      name       string
+      roleTitle  string
+      title      string
+      role       docgraph.Document
+      assignment string
+      husd       string
+      hypha      string
+      hvoice     string
+      usd        string
+    }{
+      {
+        name:       "role1 - 100% 100%",
+        roleTitle:  "Underwater Basketweaver",
+        title:      "Underwater Basketweaver - Atlantic",
+        role:       role1Doc,
+        assignment: assignment1,
+        husd:       "0.00 HUSD",
+        hypha:      "759.75 HYPHA",
+        hvoice:     "6078.02 HVOICE",
+        usd:        "3039.01 USD",
+      },
+    }
 
-		for _, test := range tests {
+    for _, test := range tests {
 
-			t.Log("\n\nStarting test: ", test.name)
+      t.Log("\n\nStarting test: ", test.name)
 
-			_, err := dao.ProposeAssignment(env.ctx, &env.api, env.DAO, proposer.Member, assignee.Member, test.role.Hash, env.Periods[0].Hash, test.assignment)
+      _, err := dao.ProposeAssignment(env.ctx, &env.api, env.DAO, proposer.Member, assignee.Member, test.role.Hash, env.Periods[0].Hash, test.assignment)
+      assert.NilError(t, err)
+
+      // retrieve the document we just created
+      proposal, err := docgraph.GetLastDocumentOfEdge(env.ctx, &env.api, env.DAO, eos.Name("proposal"))
+      assert.NilError(t, err)
+
+      voteToPassTD(t, env, proposal)
+
+      //Wait Half Period to close the proposal and test the special
+      //case when approved time overlaps in the first period
+      t.Log("Waiting for a period to lapse...")
+      pause(t, env.PeriodPause/2, "", "Waiting...")
+
+      _, err = dao.CloseProposal(env.ctx, &env.api, env.DAO, closer.Member, proposal.Hash)
+      assert.NilError(t, err)
+
+      assignment, err := docgraph.GetLastDocumentOfEdge(env.ctx, &env.api, env.DAO, eos.Name("assignment"))
+      assert.NilError(t, err)
+
+      var periodDuration float32
+      var firstPeriodStartSecs int64
+      var firstPeriodEndSecs int64
+      //Get starting period to calculate half period duration
+      {
+        periodHash, err := assignment.GetContent("start_period")
+        assert.NilError(t, err)
+        period, err := docgraph.LoadDocument(env.ctx, &env.api, env.DAO, periodHash.String())
+        assert.NilError(t, err)
+        startTime, err := period.GetContent("start_time")
+        assert.NilError(t, err)
+        firstPeriodStartSecs = int64(startTime.Impl.(eos.TimePoint)) / 1000000
+        nextPeriods, err := docgraph.GetEdgesFromDocumentWithEdge(env.ctx, &env.api, env.DAO, period, eos.Name("next"))
+        assert.NilError(t, err)
+        nextPeriod, err := docgraph.LoadDocument(env.ctx, &env.api, env.DAO, nextPeriods[0].ToNode.String())
+        assert.NilError(t, err)
+        startTime, err = nextPeriod.GetContent("start_time")
+        assert.NilError(t, err)
+        firstPeriodEndSecs = int64(startTime.Impl.(eos.TimePoint)) / 1000000
+      }
+
+      //Create Adjustment 2.5 Periods after start period
+      CreateAdjustmentAfter(int64(50), firstPeriodStartSecs,
+        env.PeriodDuration*5/2,
+        &assignment,
+        &assignee, env, t)
+
+      //Create Adjustment 3.33 Periods after start period
+      CreateAdjustmentAfter(int64(100),
+        firstPeriodStartSecs,
+        env.PeriodDuration*10/3,
+        &assignment,
+        &assignee, env, t)
+
+      //Create Adjustment 3.66 Periods after start period
+      CreateAdjustmentAfter(int64(75),
+        firstPeriodStartSecs,
+        env.PeriodDuration*11/3,
+        &assignment,
+        &assignee, env, t)
+
+      //TODO: Calculate seeds_per_usd using tlosto.seeds table
+      //Set to 0 to temporaly disable  calculating SEEDS
+      hardcodedSeedsPerUsd := float32(0) /*float32(39.0840)*/
+      var seedsDeferralFactor float32
+      {
+        settings, err := docgraph.GetLastDocumentOfEdge(env.ctx, &env.api, env.DAO, eos.Name("settings"))
+
+        seedsDeferral, err := settings.GetContent("seeds_deferral_factor_x100")
+        assert.NilError(t, err)
+
+        seedsDeferralFactor = float32(seedsDeferral.Impl.(int64)) / 100.0
+      }
+
+      usdSalaryPerPhase := float32(3039.01)
+
+      //Number of HYPHA tokens received in 1 full period
+      totalHYPHA := float32(759.75)
+
+      //Number of HUSD tokens received in 1 full period
+      totalHUSD := float32(0)
+
+      //Number of HVOICE tokens received in 1 full period
+      totalHVOICE := float32(usdSalaryPerPhase * 2.0)
+
+      //Number of seeds received in 1 full period
+      totalSEEDS := usdSalaryPerPhase * hardcodedSeedsPerUsd * seedsDeferralFactor
+
+      //Claim first period
+      t.Log("Waiting for a period to lapse...")
+      pause(t, env.PeriodPause, "", "Waiting...")
+
+      //This should get partial payment since the approved time should be > than
+      //the start time of the period
+      _, err = ClaimNextPeriod(t, env, assignee.Member, assignment)
+      assert.NilError(t, err)
+
+      {
+        initTimeShare, err := docgraph.GetLastDocumentOfEdge(env.ctx, &env.api, env.DAO, eos.Name("initimeshare"))
+        assert.NilError(t, err)
+        approvedTime, err := initTimeShare.GetContent("start_date")
+        approvedSecs := int64(approvedTime.Impl.(eos.TimePoint)) / 1000000
+        periodDuration = float32(firstPeriodEndSecs - firstPeriodStartSecs)
+        timeFactor := float32(firstPeriodEndSecs-approvedSecs) / periodDuration
+        ValidateLastReceipt(int64(totalHUSD*timeFactor),
+          int64(totalHYPHA*timeFactor),
+          int64(totalHVOICE*timeFactor),
+          int64(totalSEEDS*timeFactor), env, t)
+      }
+
+      //Claim second period
+      t.Log("Waiting for a period to lapse...")
+      pause(t, env.PeriodPause, "", "Waiting...")
+
+      //This should get full payment since the first 50% adjustment takes
+      //place on the next period
+      _, err = ClaimNextPeriod(t, env, assignee.Member, assignment)
+      assert.NilError(t, err)
+
+      //Ignore decimal precision.
+      ValidateLastReceipt(int64(totalHUSD), int64(totalHYPHA), int64(totalHVOICE), int64(totalSEEDS), env, t)
+
+      //Claim third period
+      t.Log("Waiting for another period to lapse...")
+      pause(t, env.PeriodPause, "", "Waiting...")
+
+      //This should get full payment for the first half of the period
+      //and then half payment for the last half of the period
+      _, err = ClaimNextPeriod(t, env, assignee.Member, assignment)
+      assert.NilError(t, err)
+
+      {
+        //Period Duration
+        half := int64(periodDuration) / 2
+        firstHalf := float32(half) / periodDuration
+        secondHalf := (periodDuration - float32(half)) / periodDuration
+        newTotalSEEDS := totalSEEDS*firstHalf + totalSEEDS*float32(0.5)*secondHalf
+        newTotalHYPHA := totalHYPHA*firstHalf + totalHYPHA*float32(0.5)*secondHalf
+        newTotalHVOICE := totalHVOICE*firstHalf + totalHVOICE*float32(0.5)*secondHalf
+        newTotalHUSD := totalHUSD*firstHalf + totalHUSD*float32(0.5)*secondHalf
+        ValidateLastReceipt(int64(newTotalHUSD), int64(newTotalHYPHA), int64(newTotalHVOICE), int64(newTotalSEEDS), env, t)
+      }
+
+      //Claim last period
+      t.Log("Waiting for another period to lapse...")
+      pause(t, env.PeriodPause, "", "Waiting...")
+
+      //This should get half payment for the first third,
+      //full payment on the second third &
+      //75% of payment on the last third
+      _, err = ClaimNextPeriod(t, env, assignee.Member, assignment)
+      assert.NilError(t, err)
+
+      {
+        newTotalSEEDS := CalculateTotalCompensation(0.5, 1.0, 0.75, totalSEEDS)
+        newTotalHYPHA := CalculateTotalCompensation(0.5, 1.0, 0.75, totalHYPHA)
+        newTotalHVOICE := CalculateTotalCompensation(0.5, 1.0, 0.75, totalHVOICE)
+        newTotalHUSD := CalculateTotalCompensation(0.5, 1.0, 0.75, totalHUSD)
+        ValidateLastReceipt(int64(newTotalHUSD), int64(newTotalHYPHA), int64(newTotalHVOICE), int64(newTotalSEEDS), env, t)
+      }
+    }
+  })
+}
+
+func TestWithdrawAssignment(t *testing.T) {
+  teardownTestCase := setupTestCase(t)
+  defer teardownTestCase(t)
+
+  env = SetupEnvironment(t)
+  t.Log(env.String())
+  t.Log("\nDAO Environment Setup complete\n")
+
+  // roles
+  proposer := env.Members[0]
+  assignee := env.Members[1]
+  closer := env.Members[2]
+
+  role1Doc := CreateRole(t, env, proposer, closer, role1)
+
+  t.Run("Test Withdraw Assignment", func(t *testing.T) {
+
+    tests := []struct {
+      name       string
+      roleTitle  string
+      title      string
+      role       docgraph.Document
+      assignment string
+      husd       string
+      hypha      string
+      hvoice     string
+      usd        string
+    }{
+      {
+        name:       "role1 - 100% 100%",
+        roleTitle:  "Underwater Basketweaver",
+        title:      "Underwater Basketweaver - Atlantic",
+        role:       role1Doc,
+        assignment: assignment1,
+        husd:       "0.00 HUSD",
+        hypha:      "759.75 HYPHA",
+        hvoice:     "6078.02 HVOICE",
+        usd:        "3039.01 USD",
+      },
+    }
+
+    for _, test := range tests {
+
+      t.Log("\n\nStarting test: ", test.name)
+
+      _, err := dao.ProposeAssignment(env.ctx, &env.api, env.DAO, proposer.Member, assignee.Member, test.role.Hash, env.Periods[0].Hash, test.assignment)
+      assert.NilError(t, err)
+
+      // retrieve the document we just created
+      proposal, err := docgraph.GetLastDocumentOfEdge(env.ctx, &env.api, env.DAO, eos.Name("proposal"))
+      assert.NilError(t, err)
+
+      voteToPassTD(t, env, proposal)
+
+      _, err = dao.CloseProposal(env.ctx, &env.api, env.DAO, closer.Member, proposal.Hash)
+      assert.NilError(t, err)
+
+      assignment, err := docgraph.GetLastDocumentOfEdge(env.ctx, &env.api, env.DAO, eos.Name("assignment"))
+      assert.NilError(t, err)
+
+      var periodDuration float32
+      var firstPeriodStartSecs int64
+      var firstPeriodEndSecs int64
+      //Get starting period to calculate half period duration
+      {
+        periodHash, err := assignment.GetContent("start_period")
+        assert.NilError(t, err)
+        period, err := docgraph.LoadDocument(env.ctx, &env.api, env.DAO, periodHash.String())
+        assert.NilError(t, err)
+        startTime, err := period.GetContent("start_time")
+        assert.NilError(t, err)
+        firstPeriodStartSecs = int64(startTime.Impl.(eos.TimePoint)) / 1000000
+        nextPeriods, err := docgraph.GetEdgesFromDocumentWithEdge(env.ctx, &env.api, env.DAO, period, eos.Name("next"))
+        assert.NilError(t, err)
+        nextPeriod, err := docgraph.LoadDocument(env.ctx, &env.api, env.DAO, nextPeriods[0].ToNode.String())
+        assert.NilError(t, err)
+        startTime, err = nextPeriod.GetContent("start_time")
+        assert.NilError(t, err)
+        firstPeriodEndSecs = int64(startTime.Impl.(eos.TimePoint)) / 1000000
+      }
+
+      //Create Adjustment 0.5 Periods after start period
+      CreateAdjustmentAfter(int64(50), firstPeriodStartSecs,
+                            env.PeriodDuration/2,
+                            &assignment,
+                            &assignee, env, t)
+
+      usdSalaryPerPhase := float32(3039.01)
+
+      //Number of HYPHA tokens received in 1 full period
+      totalHYPHA := float32(759.75)
+
+      //Number of HUSD tokens received in 1 full period
+      totalHUSD := float32(0)
+
+      //Number of HVOICE tokens received in 1 full period
+      totalHVOICE := float32(usdSalaryPerPhase * 2.0)
+
+      //Number of seeds received in 1 full period
+      totalSEEDS := float32(0)
+
+			totalPeriods := 9 //Number of periods for this assignment
+
+			claimedPeriods := 0
+
+      //Claim first period
+      t.Log("Waiting for 2 periods to lapse...")
+      pause(t, env.PeriodPause * 2, "", "Waiting...")
+
+      //This should get half payment since we changed the commitment to half
+      //the start time of the period
+      _, err = ClaimNextPeriod(t, env, assignee.Member, assignment)
+      assert.NilError(t, err)
+
+			claimedPeriods++
+      
+      periodDuration = float32(firstPeriodEndSecs - firstPeriodStartSecs)
+
+      {
+        //Period Duration
+        half := int64(periodDuration) / 2
+        firstHalf := float32(half) / periodDuration
+        secondHalf := (periodDuration - float32(half)) / periodDuration
+        newTotalSEEDS := totalSEEDS*firstHalf + totalSEEDS*float32(0.5)*secondHalf
+        newTotalHYPHA := totalHYPHA*firstHalf + totalHYPHA*float32(0.5)*secondHalf
+        newTotalHVOICE := totalHVOICE*firstHalf + totalHVOICE*float32(0.5)*secondHalf
+        newTotalHUSD := totalHUSD*firstHalf + totalHUSD*float32(0.5)*secondHalf
+        ValidateLastReceipt(int64(newTotalHUSD), int64(newTotalHYPHA), int64(newTotalHVOICE), int64(newTotalSEEDS), env, t)
+      }
+
+      //Withdraw assignment
+			_, err = WithdrawAssignment(env, assignee.Member, assignment.Hash)
+			assert.NilError(t, err)			
+
+			assignment, err = docgraph.GetLastDocumentOfEdge(env.ctx, &env.api, env.DAO, eos.Name("assignment"))
+      assert.NilError(t, err)
+			//Claiming should not work before the end period
+			claimed := true
+
+			for claimed {
+				//Claim next
+				t.Log("Waiting for another period to lapse...")
+				pause(t, env.PeriodPause, "", "Waiting...")
+
+				_, err = ClaimNextPeriod(t, env, assignee.Member, assignment)
+
+				if err == nil {
+					claimedPeriods++
+				} else {
+					assert.ErrorContains(t, err, "All available periods for this assignment have been claimed:")
+					claimed = false
+				}
+			}
+			
+      assert.Assert(t, claimedPeriods < totalPeriods, "Claimed periods should be less than original approved periods")
+    }
+  })
+}
+
+func TestSuspendAssignment(t *testing.T) {
+  teardownTestCase := setupTestCase(t)
+  defer teardownTestCase(t)
+
+  env = SetupEnvironment(t)
+  t.Log(env.String())
+  t.Log("\nDAO Environment Setup complete\n")
+
+  // roles
+  proposer := env.Members[0]
+  assignee := env.Members[1]
+  closer := env.Members[2]
+
+  role1Doc := CreateRole(t, env, proposer, closer, role1)
+
+  t.Run("Test Suspend Assignment", func(t *testing.T) {
+
+    tests := []struct {
+      name       string
+      roleTitle  string
+      title      string
+      role       docgraph.Document
+      assignment string
+      husd       string
+      hypha      string
+      hvoice     string
+      usd        string
+    }{
+      {
+        name:       "role1 - 100% 100%",
+        roleTitle:  "Underwater Basketweaver",
+        title:      "Underwater Basketweaver - Atlantic",
+        role:       role1Doc,
+        assignment: assignment1,
+        husd:       "0.00 HUSD",
+        hypha:      "759.75 HYPHA",
+        hvoice:     "6078.02 HVOICE",
+        usd:        "3039.01 USD",
+      },
+    }
+
+    for _, test := range tests {
+
+      t.Log("\n\nStarting test: ", test.name)
+
+      _, err := dao.ProposeAssignment(env.ctx, &env.api, env.DAO, proposer.Member, assignee.Member, test.role.Hash, env.Periods[0].Hash, test.assignment)
+      assert.NilError(t, err)
+
+      // retrieve the document we just created
+      proposal, err := docgraph.GetLastDocumentOfEdge(env.ctx, &env.api, env.DAO, eos.Name("proposal"))
+      assert.NilError(t, err)
+
+      voteToPassTD(t, env, proposal)
+
+      _, err = dao.CloseProposal(env.ctx, &env.api, env.DAO, closer.Member, proposal.Hash)
+      assert.NilError(t, err)
+
+      assignment, err := docgraph.GetLastDocumentOfEdge(env.ctx, &env.api, env.DAO, eos.Name("assignment"))
+      assert.NilError(t, err)
+
+      var periodDuration float32
+      var firstPeriodStartSecs int64
+      var firstPeriodEndSecs int64
+      //Get starting period to calculate half period duration
+      {
+        periodHash, err := assignment.GetContent("start_period")
+        assert.NilError(t, err)
+        period, err := docgraph.LoadDocument(env.ctx, &env.api, env.DAO, periodHash.String())
+        assert.NilError(t, err)
+        startTime, err := period.GetContent("start_time")
+        assert.NilError(t, err)
+        firstPeriodStartSecs = int64(startTime.Impl.(eos.TimePoint)) / 1000000
+        nextPeriods, err := docgraph.GetEdgesFromDocumentWithEdge(env.ctx, &env.api, env.DAO, period, eos.Name("next"))
+        assert.NilError(t, err)
+        nextPeriod, err := docgraph.LoadDocument(env.ctx, &env.api, env.DAO, nextPeriods[0].ToNode.String())
+        assert.NilError(t, err)
+        startTime, err = nextPeriod.GetContent("start_time")
+        assert.NilError(t, err)
+        firstPeriodEndSecs = int64(startTime.Impl.(eos.TimePoint)) / 1000000
+      }
+
+      //Create Adjustment 0.5 Periods after start period
+      CreateAdjustmentAfter(int64(50), firstPeriodStartSecs,
+                            env.PeriodDuration/2,
+                            &assignment,
+                            &assignee, env, t)
+
+      usdSalaryPerPhase := float32(3039.01)
+
+      //Number of HYPHA tokens received in 1 full period
+      totalHYPHA := float32(759.75)
+
+      //Number of HUSD tokens received in 1 full period
+      totalHUSD := float32(0)
+
+      //Number of HVOICE tokens received in 1 full period
+      totalHVOICE := float32(usdSalaryPerPhase * 2.0)
+
+      //Number of seeds received in 1 full period
+      totalSEEDS := float32(0)
+
+			totalPeriods := 9 //Number of periods for this assignment
+
+			claimedPeriods := 0
+
+      //Claim first period
+      t.Log("Waiting for 2 periods to lapse...")
+      pause(t, env.PeriodPause * 2, "", "Waiting...")
+
+      //This should get half payment since we changed the commitment to half
+      //the start time of the period
+      _, err = ClaimNextPeriod(t, env, assignee.Member, assignment)
+      assert.NilError(t, err)
+
+			claimedPeriods++
+      
+      periodDuration = float32(firstPeriodEndSecs - firstPeriodStartSecs)
+
+      {
+        //Period Duration
+        half := int64(periodDuration) / 2
+        firstHalf := float32(half) / periodDuration
+        secondHalf := (periodDuration - float32(half)) / periodDuration
+        newTotalSEEDS := totalSEEDS*firstHalf + totalSEEDS*float32(0.5)*secondHalf
+        newTotalHYPHA := totalHYPHA*firstHalf + totalHYPHA*float32(0.5)*secondHalf
+        newTotalHVOICE := totalHVOICE*firstHalf + totalHVOICE*float32(0.5)*secondHalf
+        newTotalHUSD := totalHUSD*firstHalf + totalHUSD*float32(0.5)*secondHalf
+        ValidateLastReceipt(int64(newTotalHUSD), int64(newTotalHYPHA), int64(newTotalHVOICE), int64(newTotalSEEDS), env, t)
+      }
+
+      //Suspend Assignment			
+			_, err = SuspendAssignment(env, proposer.Member, assignment.Hash, "This assignment is no longer needed")
 			assert.NilError(t, err)
-
+			
 			// retrieve the document we just created
-			proposal, err := docgraph.GetLastDocumentOfEdge(env.ctx, &env.api, env.DAO, eos.Name("proposal"))
-			assert.NilError(t, err)
+      proposal, err = docgraph.GetLastDocumentOfEdge(env.ctx, &env.api, env.DAO, eos.Name("proposal"))
+      assert.NilError(t, err)
 
 			voteToPassTD(t, env, proposal)
 
-			//Wait Half Period to close the proposal and test the special
-			//case when approved time overlaps in the first period
-			t.Log("Waiting for a period to lapse...")
-			pause(t, env.PeriodPause/2, "", "Waiting...")
+      _, err = dao.CloseProposal(env.ctx, &env.api, env.DAO, closer.Member, proposal.Hash)
+      assert.NilError(t, err)
 
-			_, err = dao.CloseProposal(env.ctx, &env.api, env.DAO, closer.Member, proposal.Hash)
-			assert.NilError(t, err)
+			assignment, err = docgraph.GetLastDocumentOfEdge(env.ctx, &env.api, env.DAO, eos.Name("assignment"))
+      assert.NilError(t, err)
+			//Claiming should not work before the original end period
+			claimed := true
 
-			assignment, err := docgraph.GetLastDocumentOfEdge(env.ctx, &env.api, env.DAO, eos.Name("assignment"))
-			assert.NilError(t, err)
+			for claimed {
+				//Claim next
+				t.Log("Waiting for another period to lapse...")
+				pause(t, env.PeriodPause, "", "Waiting...")
 
-			var periodDuration float32
-			var firstPeriodStartSecs int64
-			var firstPeriodEndSecs int64
-			//Get starting period to calculate half period duration
-			{
-				periodHash, err := assignment.GetContent("start_period")
-				assert.NilError(t, err)
-				period, err := docgraph.LoadDocument(env.ctx, &env.api, env.DAO, periodHash.String())
-				assert.NilError(t, err)
-				startTime, err := period.GetContent("start_time")
-				assert.NilError(t, err)
-				firstPeriodStartSecs = int64(startTime.Impl.(eos.TimePoint)) / 1000000
-				nextPeriods, err := docgraph.GetEdgesFromDocumentWithEdge(env.ctx, &env.api, env.DAO, period, eos.Name("next"))
-				assert.NilError(t, err)
-				nextPeriod, err := docgraph.LoadDocument(env.ctx, &env.api, env.DAO, nextPeriods[0].ToNode.String())
-				assert.NilError(t, err)
-				startTime, err = nextPeriod.GetContent("start_time")
-				assert.NilError(t, err)
-				firstPeriodEndSecs = int64(startTime.Impl.(eos.TimePoint)) / 1000000
+				_, err = ClaimNextPeriod(t, env, assignee.Member, assignment)
+
+				if err == nil {
+					claimedPeriods++
+				} else {
+					assert.ErrorContains(t, err, "All available periods for this assignment have been claimed:")
+					claimed = false
+				}
 			}
-
-			//Create Adjustment 2.5 Periods after start period
-			CreateAdjustmentAfter(int64(50), firstPeriodStartSecs,
-				env.PeriodDuration*5/2,
-				&assignment,
-				&assignee, env, t)
-
-			//Create Adjustment 3.33 Periods after start period
-			CreateAdjustmentAfter(int64(100),
-				firstPeriodStartSecs,
-				env.PeriodDuration*10/3,
-				&assignment,
-				&assignee, env, t)
-
-			//Create Adjustment 3.66 Periods after start period
-			CreateAdjustmentAfter(int64(75),
-				firstPeriodStartSecs,
-				env.PeriodDuration*11/3,
-				&assignment,
-				&assignee, env, t)
-
-			//TODO: Calculate seeds_per_usd using tlosto.seeds table
-			//Set to 0 to temporaly disable  calculating SEEDS
-			hardcodedSeedsPerUsd := float32(0) /*float32(39.0840)*/
-			var seedsDeferralFactor float32
-			{
-				settings, err := docgraph.GetLastDocumentOfEdge(env.ctx, &env.api, env.DAO, eos.Name("settings"))
-
-				seedsDeferral, err := settings.GetContent("seeds_deferral_factor_x100")
-				assert.NilError(t, err)
-
-				seedsDeferralFactor = float32(seedsDeferral.Impl.(int64)) / 100.0
-			}
-
-			usdSalaryPerPhase := float32(3039.01)
-
-			//Number of HYPHA tokens received in 1 full period
-			totalHYPHA := float32(759.75)
-
-			//Number of HUSD tokens received in 1 full period
-			totalHUSD := float32(0)
-
-			//Number of HVOICE tokens received in 1 full period
-			totalHVOICE := float32(usdSalaryPerPhase * 2.0)
-
-			//Number of seeds received in 1 full period
-			totalSEEDS := usdSalaryPerPhase * hardcodedSeedsPerUsd * seedsDeferralFactor
-
-			//Claim first period
-			t.Log("Waiting for a period to lapse...")
-			pause(t, env.PeriodPause, "", "Waiting...")
-
-			//This should get partial payment since the approved time should be > than
-			//the start time of the period
-			_, err = ClaimNextPeriod(t, env, assignee.Member, assignment)
-			assert.NilError(t, err)
-
-			{
-				initTimeShare, err := docgraph.GetLastDocumentOfEdge(env.ctx, &env.api, env.DAO, eos.Name("initimeshare"))
-				assert.NilError(t, err)
-				approvedTime, err := initTimeShare.GetContent("start_date")
-				approvedSecs := int64(approvedTime.Impl.(eos.TimePoint)) / 1000000
-				periodDuration = float32(firstPeriodEndSecs - firstPeriodStartSecs)
-				timeFactor := float32(firstPeriodEndSecs-approvedSecs) / periodDuration
-				ValidateLastReceipt(int64(totalHUSD*timeFactor),
-					int64(totalHYPHA*timeFactor),
-					int64(totalHVOICE*timeFactor),
-					int64(totalSEEDS*timeFactor), env, t)
-			}
-
-			//Claim second period
-			t.Log("Waiting for a period to lapse...")
-			pause(t, env.PeriodPause, "", "Waiting...")
-
-			//This should get full payment since the first 50% adjustment takes
-			//place on the next period
-			_, err = ClaimNextPeriod(t, env, assignee.Member, assignment)
-			assert.NilError(t, err)
-
-			//Ignore decimal precision.
-			ValidateLastReceipt(int64(totalHUSD), int64(totalHYPHA), int64(totalHVOICE), int64(totalSEEDS), env, t)
-
-			//Claim third period
-			t.Log("Waiting for another period to lapse...")
-			pause(t, env.PeriodPause, "", "Waiting...")
-
-			//This should get full payment for the first half of the period
-			//and then half payment for the last half of the period
-			_, err = ClaimNextPeriod(t, env, assignee.Member, assignment)
-			assert.NilError(t, err)
-
-			{
-				//Period Duration
-				half := int64(periodDuration) / 2
-				firstHalf := float32(half) / periodDuration
-				secondHalf := (periodDuration - float32(half)) / periodDuration
-				newTotalSEEDS := totalSEEDS*firstHalf + totalSEEDS*float32(0.5)*secondHalf
-				newTotalHYPHA := totalHYPHA*firstHalf + totalHYPHA*float32(0.5)*secondHalf
-				newTotalHVOICE := totalHVOICE*firstHalf + totalHVOICE*float32(0.5)*secondHalf
-				newTotalHUSD := totalHUSD*firstHalf + totalHUSD*float32(0.5)*secondHalf
-				ValidateLastReceipt(int64(newTotalHUSD), int64(newTotalHYPHA), int64(newTotalHVOICE), int64(newTotalSEEDS), env, t)
-			}
-
-			//Claim last period
-			t.Log("Waiting for another period to lapse...")
-			pause(t, env.PeriodPause, "", "Waiting...")
-
-			//This should get half payment for the first third,
-			//full payment on the second third &
-			//75% of payment on the last third
-			_, err = ClaimNextPeriod(t, env, assignee.Member, assignment)
-			assert.NilError(t, err)
-
-			{
-				newTotalSEEDS := CalculateTotalCompensation(0.5, 1.0, 0.75, totalSEEDS)
-				newTotalHYPHA := CalculateTotalCompensation(0.5, 1.0, 0.75, totalHYPHA)
-				newTotalHVOICE := CalculateTotalCompensation(0.5, 1.0, 0.75, totalHVOICE)
-				newTotalHUSD := CalculateTotalCompensation(0.5, 1.0, 0.75, totalHUSD)
-				ValidateLastReceipt(int64(newTotalHUSD), int64(newTotalHYPHA), int64(newTotalHVOICE), int64(newTotalSEEDS), env, t)
-			}
-		}
-	})
+			
+      assert.Assert(t, claimedPeriods < totalPeriods, "Claimed periods should be less than original approved periods")
+    }
+  })
 }
 
 func TestAssignmentProposalDocument(t *testing.T) {
-	teardownTestCase := setupTestCase(t)
-	defer teardownTestCase(t)
+  teardownTestCase := setupTestCase(t)
+  defer teardownTestCase(t)
 
-	env = SetupEnvironment(t)
-	t.Log(env.String())
-	t.Log("\nDAO Environment Setup complete\n")
+  env = SetupEnvironment(t)
+  t.Log(env.String())
+  t.Log("\nDAO Environment Setup complete\n")
 
-	// roles
-	proposer := env.Members[0]
-	assignee := env.Members[1]
-	closer := env.Members[2]
+  // roles
+  proposer := env.Members[0]
+  assignee := env.Members[1]
+  closer := env.Members[2]
 
-	role1Doc := CreateRole(t, env, proposer, closer, role1)
-	role2Doc := CreateRole(t, env, proposer, closer, role2)
-	role3Doc := CreateRole(t, env, proposer, closer, role3)
+  role1Doc := CreateRole(t, env, proposer, closer, role1)
+  role2Doc := CreateRole(t, env, proposer, closer, role2)
+  role3Doc := CreateRole(t, env, proposer, closer, role3)
 
-	t.Run("Test Assignment Document Proposal", func(t *testing.T) {
+  t.Run("Test Assignment Document Proposal", func(t *testing.T) {
 
-		tests := []struct {
-			name       string
-			roleTitle  string
-			title      string
-			role       docgraph.Document
-			assignment string
-			husd       string
-			hypha      string
-			hvoice     string
-			usd        string
-		}{
-			{
-				name:       "role1 - 100% 100%",
-				roleTitle:  "Underwater Basketweaver",
-				title:      "Underwater Basketweaver - Atlantic",
-				role:       role1Doc,
-				assignment: assignment1,
-				husd:       "0.00 HUSD",
-				hypha:      "759.75 HYPHA",
-				hvoice:     "6078.02 HVOICE",
-				usd:        "3039.01 USD",
-			},
-			{
-				name:       "role2 - 100% commit, 70% deferred",
-				roleTitle:  "Underwater Basketweaver",
-				title:      "Underwater Basketweaver - Atlantic",
-				role:       role2Doc,
-				assignment: assignment2,
-				husd:       "455.85 HUSD",
-				hypha:      "265.91 HYPHA",
-				hvoice:     "3039.00 HVOICE",
-				usd:        "1519.50 USD",
-			},
-			{
-				name:       "role2 - 75% commit, 50% deferred",
-				roleTitle:  "Underwater Basketweaver",
-				title:      "Underwater Basketweaver - Atlantic",
-				role:       role2Doc,
-				assignment: assignment3,
-				husd:       "569.81 HUSD",
-				hypha:      "142.45 HYPHA",
-				hvoice:     "2279.26 HVOICE",
-				usd:        "1519.50 USD",
-			},
-			{
-				name:       "role3 - 51% commit, 100% deferred",
-				roleTitle:  "Underwater Basketweaver",
-				title:      "Underwater Basketweaver - Atlantic",
-				role:       role3Doc,
-				assignment: assignment4,
-				husd:       "0.00 HUSD",
-				hypha:      "452.05 HYPHA",
-				hvoice:     "3616.42 HVOICE",
-				usd:        "3545.51 USD",
-			},
-			{
-				name:       "role3 - 25% commit, 50% deferred",
-				roleTitle:  "Underwater Basketweaver",
-				title:      "Underwater Basketweaver - Atlantic",
-				role:       role3Doc,
-				assignment: assignment5,
-				husd:       "443.18 HUSD",
-				hypha:      "110.79 HYPHA",
-				hvoice:     "1772.74 HVOICE",
-				usd:        "3545.51 USD",
-			},
-			{
-				name:       "role3 - 100% commit, 15% deferred",
-				roleTitle:  "Underwater Basketweaver",
-				title:      "Underwater Basketweaver - Atlantic",
-				role:       role3Doc,
-				assignment: assignment6,
-				husd:       "3013.68 HUSD",
-				hypha:      "132.95 HYPHA",
-				hvoice:     "7091.02 HVOICE",
-				usd:        "3545.51 USD",
-			},
-			{
-				name:       "role3 - 10% commit, 0% deferred",
-				roleTitle:  "Underwater Basketweaver",
-				title:      "Underwater Basketweaver - Atlantic",
-				role:       role3Doc,
-				assignment: assignment7,
-				husd:       "354.55 HUSD",
-				hypha:      "0.00 HYPHA",
-				hvoice:     "709.10 HVOICE",
-				usd:        "3545.51 USD",
-			},
-		}
+    tests := []struct {
+      name       string
+      roleTitle  string
+      title      string
+      role       docgraph.Document
+      assignment string
+      husd       string
+      hypha      string
+      hvoice     string
+      usd        string
+    }{
+      {
+        name:       "role1 - 100% 100%",
+        roleTitle:  "Underwater Basketweaver",
+        title:      "Underwater Basketweaver - Atlantic",
+        role:       role1Doc,
+        assignment: assignment1,
+        husd:       "0.00 HUSD",
+        hypha:      "759.75 HYPHA",
+        hvoice:     "6078.02 HVOICE",
+        usd:        "3039.01 USD",
+      },
+      {
+        name:       "role2 - 100% commit, 70% deferred",
+        roleTitle:  "Underwater Basketweaver",
+        title:      "Underwater Basketweaver - Atlantic",
+        role:       role2Doc,
+        assignment: assignment2,
+        husd:       "455.85 HUSD",
+        hypha:      "265.91 HYPHA",
+        hvoice:     "3039.00 HVOICE",
+        usd:        "1519.50 USD",
+      },
+      {
+        name:       "role2 - 75% commit, 50% deferred",
+        roleTitle:  "Underwater Basketweaver",
+        title:      "Underwater Basketweaver - Atlantic",
+        role:       role2Doc,
+        assignment: assignment3,
+        husd:       "569.81 HUSD",
+        hypha:      "142.45 HYPHA",
+        hvoice:     "2279.26 HVOICE",
+        usd:        "1519.50 USD",
+      },
+      {
+        name:       "role3 - 51% commit, 100% deferred",
+        roleTitle:  "Underwater Basketweaver",
+        title:      "Underwater Basketweaver - Atlantic",
+        role:       role3Doc,
+        assignment: assignment4,
+        husd:       "0.00 HUSD",
+        hypha:      "452.05 HYPHA",
+        hvoice:     "3616.42 HVOICE",
+        usd:        "3545.51 USD",
+      },
+      {
+        name:       "role3 - 25% commit, 50% deferred",
+        roleTitle:  "Underwater Basketweaver",
+        title:      "Underwater Basketweaver - Atlantic",
+        role:       role3Doc,
+        assignment: assignment5,
+        husd:       "443.18 HUSD",
+        hypha:      "110.79 HYPHA",
+        hvoice:     "1772.74 HVOICE",
+        usd:        "3545.51 USD",
+      },
+      {
+        name:       "role3 - 100% commit, 15% deferred",
+        roleTitle:  "Underwater Basketweaver",
+        title:      "Underwater Basketweaver - Atlantic",
+        role:       role3Doc,
+        assignment: assignment6,
+        husd:       "3013.68 HUSD",
+        hypha:      "132.95 HYPHA",
+        hvoice:     "7091.02 HVOICE",
+        usd:        "3545.51 USD",
+      },
+      {
+        name:       "role3 - 10% commit, 0% deferred",
+        roleTitle:  "Underwater Basketweaver",
+        title:      "Underwater Basketweaver - Atlantic",
+        role:       role3Doc,
+        assignment: assignment7,
+        husd:       "354.55 HUSD",
+        hypha:      "0.00 HYPHA",
+        hvoice:     "709.10 HVOICE",
+        usd:        "3545.51 USD",
+      },
+    }
 
-		for _, test := range tests {
+    for _, test := range tests {
 
-			t.Log("\n\nStarting test: ", test.name)
-			_, err := dao.ProposeAssignment(env.ctx, &env.api, env.DAO, proposer.Member, assignee.Member, test.role.Hash, env.Periods[0].Hash, test.assignment)
-			assert.NilError(t, err)
+      t.Log("\n\nStarting test: ", test.name)
+      _, err := dao.ProposeAssignment(env.ctx, &env.api, env.DAO, proposer.Member, assignee.Member, test.role.Hash, env.Periods[0].Hash, test.assignment)
+      assert.NilError(t, err)
 
-			// retrieve the document we just created
-			assignment, err := docgraph.GetLastDocumentOfEdge(env.ctx, &env.api, env.DAO, eos.Name("proposal"))
-			assert.NilError(t, err)
-			assert.Equal(t, assignment.Creator, proposer.Member)
+      // retrieve the document we just created
+      assignment, err := docgraph.GetLastDocumentOfEdge(env.ctx, &env.api, env.DAO, eos.Name("proposal"))
+      assert.NilError(t, err)
+      assert.Equal(t, assignment.Creator, proposer.Member)
 
-			fv, err := assignment.GetContent("title")
-			assert.NilError(t, err)
-			assert.Equal(t, fv.String(), test.title)
+      fv, err := assignment.GetContent("title")
+      assert.NilError(t, err)
+      assert.Equal(t, fv.String(), test.title)
 
-			// verify that the edges are created correctly
-			// Graph structure post creating proposal:
-			// root 		---proposal---> 	propDocument
-			// member 		---owns-------> 	propDocument
-			// propDocument ---ownedby----> 	member
-			checkEdge(t, env, env.Root, assignment, eos.Name("proposal"))
-			checkEdge(t, env, proposer.Doc, assignment, eos.Name("owns"))
-			checkEdge(t, env, assignment, proposer.Doc, eos.Name("ownedby"))
-			checkEdge(t, env, assignment, test.role, eos.Name("role"))
+      // verify that the edges are created correctly
+      // Graph structure post creating proposal:
+      // root 		---proposal---> 	propDocument
+      // member 		---owns-------> 	propDocument
+      // propDocument ---ownedby----> 	member
+      checkEdge(t, env, env.Root, assignment, eos.Name("proposal"))
+      checkEdge(t, env, proposer.Doc, assignment, eos.Name("owns"))
+      checkEdge(t, env, assignment, proposer.Doc, eos.Name("ownedby"))
+      checkEdge(t, env, assignment, test.role, eos.Name("role"))
 
-			// roleHash, err := assignment.GetContent("role")
-			// assert.NilError(t, err)
+      // roleHash, err := assignment.GetContent("role")
+      // assert.NilError(t, err)
 
-			// roleDocument, err := docgraph.LoadDocument(env.ctx, &env.api, env.DAO, roleHash.String())
-			// assert.NilError(t, err)
+      // roleDocument, err := docgraph.LoadDocument(env.ctx, &env.api, env.DAO, roleHash.String())
+      // assert.NilError(t, err)
 
-			// // check edge from assignment to role
-			// exists, err := docgraph.EdgeExists(env.ctx, &env.api, env.DAO, assignment, roleDocument, eos.Name("role"))
-			// assert.NilError(t, err)
-			// if !exists {
-			// 	t.Log("Edge does not exist	: ", assignment.Hash.String(), "	-- role	--> 	", roleDocument.Hash.String())
-			// }
-			// assert.Check(t, exists)
+      // // check edge from assignment to role
+      // exists, err := docgraph.EdgeExists(env.ctx, &env.api, env.DAO, assignment, roleDocument, eos.Name("role"))
+      // assert.NilError(t, err)
+      // if !exists {
+      // 	t.Log("Edge does not exist	: ", assignment.Hash.String(), "	-- role	--> 	", roleDocument.Hash.String())
+      // }
+      // assert.Check(t, exists)
 
-			voteToPassTD(t, env, assignment)
+      voteToPassTD(t, env, assignment)
 
-			t.Log("Member: ", closer.Member, " is closing assignment proposal	: ", assignment.Hash.String())
-			_, err = dao.CloseProposal(env.ctx, &env.api, env.DAO, closer.Member, assignment.Hash)
-			assert.NilError(t, err)
+      t.Log("Member: ", closer.Member, " is closing assignment proposal	: ", assignment.Hash.String())
+      _, err = dao.CloseProposal(env.ctx, &env.api, env.DAO, closer.Member, assignment.Hash)
+      assert.NilError(t, err)
 
-			assignment, err = docgraph.GetLastDocumentOfEdge(env.ctx, &env.api, env.DAO, eos.Name("assignment"))
-			assert.NilError(t, err)
+      assignment, err = docgraph.GetLastDocumentOfEdge(env.ctx, &env.api, env.DAO, eos.Name("assignment"))
+      assert.NilError(t, err)
 
-			// verify that the edges are created correctly
-			// Graph structure post creating proposal:
-			// update graph edges:
-			//  member          ---- assigned           ---->   role_assignment
-			//  role_assignment ---- assignee           ---->   member
-			//  role_assignment ---- role               ---->   role
-			//  role            ---- role_assignment    ---->   role_assignment
-			checkEdge(t, env, assignee.Doc, assignment, eos.Name("assigned"))
-			checkEdge(t, env, assignment, assignee.Doc, eos.Name("assignee"))
-			checkEdge(t, env, assignment, test.role, eos.Name("role"))
-			checkEdge(t, env, test.role, assignment, eos.Name("assignment"))
+      // verify that the edges are created correctly
+      // Graph structure post creating proposal:
+      // update graph edges:
+      //  member          ---- assigned           ---->   role_assignment
+      //  role_assignment ---- assignee           ---->   member
+      //  role_assignment ---- role               ---->   role
+      //  role            ---- role_assignment    ---->   role_assignment
+      checkEdge(t, env, assignee.Doc, assignment, eos.Name("assigned"))
+      checkEdge(t, env, assignment, assignee.Doc, eos.Name("assignee"))
+      checkEdge(t, env, assignment, test.role, eos.Name("role"))
+      checkEdge(t, env, test.role, assignment, eos.Name("assignment"))
 
-			//  root ---- passedprops        ---->   role_assignment
-			checkEdge(t, env, env.Root, assignment, eos.Name("passedprops"))
+      //  root ---- passedprops        ---->   role_assignment
+      checkEdge(t, env, env.Root, assignment, eos.Name("passedprops"))
 
-			fetchedAssignment, err := docgraph.GetLastDocumentOfEdge(env.ctx, &env.api, env.DAO, eos.Name("assignment"))
+      fetchedAssignment, err := docgraph.GetLastDocumentOfEdge(env.ctx, &env.api, env.DAO, eos.Name("assignment"))
 
-			testHusdAsset, err := eos.NewAssetFromString(test.husd)
-			assert.NilError(t, err)
-			testHyphaAsset, err := eos.NewAssetFromString(test.hypha)
-			assert.NilError(t, err)
-			testHvoiceAsset, err := eos.NewAssetFromString(test.hvoice)
-			assert.NilError(t, err)
-			testUsdAsset, err := eos.NewAssetFromString(test.usd)
-			assert.NilError(t, err)
+      testHusdAsset, err := eos.NewAssetFromString(test.husd)
+      assert.NilError(t, err)
+      testHyphaAsset, err := eos.NewAssetFromString(test.hypha)
+      assert.NilError(t, err)
+      testHvoiceAsset, err := eos.NewAssetFromString(test.hvoice)
+      assert.NilError(t, err)
+      testUsdAsset, err := eos.NewAssetFromString(test.usd)
+      assert.NilError(t, err)
 
-			husd, err := fetchedAssignment.GetContent("husd_salary_per_phase")
-			if testHusdAsset.Amount != 0 {
-				assert.NilError(t, err)
-				t.Log("test: ", test.name, ": husd: "+husd.String())
-				assert.Equal(t, husd.String(), test.husd)
-			} else {
-				assert.ErrorContains(t, err, "content label not found")
-			}
+      husd, err := fetchedAssignment.GetContent("husd_salary_per_phase")
+      if testHusdAsset.Amount != 0 {
+        assert.NilError(t, err)
+        t.Log("test: ", test.name, ": husd: "+husd.String())
+        assert.Equal(t, husd.String(), test.husd)
+      } else {
+        assert.ErrorContains(t, err, "content label not found")
+      }
 
-			hypha, err := fetchedAssignment.GetContent("hypha_salary_per_phase")
-			if testHyphaAsset.Amount != 0 {
-				assert.NilError(t, err)
-				t.Log("test: ", test.name, ": hypha: "+hypha.String())
-				assert.Equal(t, hypha.String(), test.hypha)
-			} else {
-				assert.ErrorContains(t, err, "content label not found")
-			}
+      hypha, err := fetchedAssignment.GetContent("hypha_salary_per_phase")
+      if testHyphaAsset.Amount != 0 {
+        assert.NilError(t, err)
+        t.Log("test: ", test.name, ": hypha: "+hypha.String())
+        assert.Equal(t, hypha.String(), test.hypha)
+      } else {
+        assert.ErrorContains(t, err, "content label not found")
+      }
 
-			hvoice, err := fetchedAssignment.GetContent("hvoice_salary_per_phase")
-			if testHvoiceAsset.Amount != 0 {
-				assert.NilError(t, err)
-				t.Log("test: ", test.name, ": hvoice: "+hvoice.String())
-				assert.Equal(t, hvoice.String(), test.hvoice)
-			} else {
-				assert.ErrorContains(t, err, "content label not found")
-			}
+      hvoice, err := fetchedAssignment.GetContent("hvoice_salary_per_phase")
+      if testHvoiceAsset.Amount != 0 {
+        assert.NilError(t, err)
+        t.Log("test: ", test.name, ": hvoice: "+hvoice.String())
+        assert.Equal(t, hvoice.String(), test.hvoice)
+      } else {
+        assert.ErrorContains(t, err, "content label not found")
+      }
 
-			usd, err := fetchedAssignment.GetContent("usd_salary_value_per_phase")
-			if testUsdAsset.Amount != 0 {
-				assert.NilError(t, err)
-				t.Log("test: ", test.name, ": usd: "+usd.String())
-				assert.Equal(t, usd.String(), test.usd)
-			} else {
-				assert.ErrorContains(t, err, "content label not found")
-			}
-		}
-	})
+      usd, err := fetchedAssignment.GetContent("usd_salary_value_per_phase")
+      if testUsdAsset.Amount != 0 {
+        assert.NilError(t, err)
+        t.Log("test: ", test.name, ": usd: "+usd.String())
+        assert.Equal(t, usd.String(), test.usd)
+      } else {
+        assert.ErrorContains(t, err, "content label not found")
+      }
+    }
+  })
 }
 
 func TestAssignmentDefaults(t *testing.T) {
-	teardownTestCase := setupTestCase(t)
-	defer teardownTestCase(t)
+  teardownTestCase := setupTestCase(t)
+  defer teardownTestCase(t)
 
-	env = SetupEnvironment(t)
-	t.Log(env.String())
-	t.Log("\nDAO Environment Setup complete\n")
+  env = SetupEnvironment(t)
+  t.Log(env.String())
+  t.Log("\nDAO Environment Setup complete\n")
 
-	// roles
-	proposer := env.Members[0]
-	assignee := env.Members[1]
-	closer := env.Members[2]
+  // roles
+  proposer := env.Members[0]
+  assignee := env.Members[1]
+  closer := env.Members[2]
 
-	role1Doc := CreateRole(t, env, proposer, closer, role1)
+  role1Doc := CreateRole(t, env, proposer, closer, role1)
 
-	t.Run("Test Assignment Document Proposal", func(t *testing.T) {
+  t.Run("Test Assignment Document Proposal", func(t *testing.T) {
 
-		tests := []struct {
-			name               string
-			roleTitle          string
-			title              string
-			role               docgraph.Document
-			assignment         string
-			defaultPeriodCount int64
-			hypha              string
-			hvoice             string
-			usd                string
-		}{
-			{
-				name:               "role1 - 100% 100%",
-				roleTitle:          "Underwater Basketweaver",
-				title:              "Underwater Basketweaver - Atlantic",
-				role:               role1Doc,
-				assignment:         assignment8,
-				defaultPeriodCount: 13,
-			},
-		}
+    tests := []struct {
+      name               string
+      roleTitle          string
+      title              string
+      role               docgraph.Document
+      assignment         string
+      defaultPeriodCount int64
+      hypha              string
+      hvoice             string
+      usd                string
+    }{
+      {
+        name:               "role1 - 100% 100%",
+        roleTitle:          "Underwater Basketweaver",
+        title:              "Underwater Basketweaver - Atlantic",
+        role:               role1Doc,
+        assignment:         assignment8,
+        defaultPeriodCount: 13,
+      },
+    }
 
-		for _, test := range tests {
+    for _, test := range tests {
 
-			t.Log("\n\nStarting test: ", test.name)
-			_, err := dao.ProposeAssignment(env.ctx, &env.api, env.DAO, proposer.Member, assignee.Member, test.role.Hash, env.Periods[0].Hash, test.assignment)
-			assert.NilError(t, err)
+      t.Log("\n\nStarting test: ", test.name)
+      _, err := dao.ProposeAssignment(env.ctx, &env.api, env.DAO, proposer.Member, assignee.Member, test.role.Hash, env.Periods[0].Hash, test.assignment)
+      assert.NilError(t, err)
 
-			// retrieve the document we just created
-			assignment, err := docgraph.GetLastDocumentOfEdge(env.ctx, &env.api, env.DAO, eos.Name("proposal"))
-			assert.NilError(t, err)
-			assert.Equal(t, assignment.Creator, proposer.Member)
+      // retrieve the document we just created
+      assignment, err := docgraph.GetLastDocumentOfEdge(env.ctx, &env.api, env.DAO, eos.Name("proposal"))
+      assert.NilError(t, err)
+      assert.Equal(t, assignment.Creator, proposer.Member)
 
-			fv, err := assignment.GetContent("period_count")
-			assert.NilError(t, err)
-			assert.Equal(t, fv.Impl.(int64), test.defaultPeriodCount)
-		}
-	})
+      fv, err := assignment.GetContent("period_count")
+      assert.NilError(t, err)
+      assert.Equal(t, fv.Impl.(int64), test.defaultPeriodCount)
+    }
+  })
 }
 
 func TestOldAssignmentsPayClaim(t *testing.T) {
-	teardownTestCase := setupTestCase(t)
-	defer teardownTestCase(t)
+  teardownTestCase := setupTestCase(t)
+  defer teardownTestCase(t)
 
-	env = SetupEnvironment(t)
+  env = SetupEnvironment(t)
 
-	proposer := env.Members[0]
+  proposer := env.Members[0]
 
-	var balances []Balance
+  var balances []Balance
 
-	balances = append(balances, NewBalance())
+  balances = append(balances, NewBalance())
 
-	t.Run("Test Assignment Document Proposal", func(t *testing.T) {
+  t.Run("Test Assignment Document Proposal", func(t *testing.T) {
 
-		tests := []struct {
-			name       string
-			roleTitle  string
-			title      string
-			role       string
-			assignment string
-			husd       string
-			hypha      string
-			hvoice     string
-			usd        string
-		}{
-			{
-				name:       "role2 - 100% commit, 70% deferred",
-				roleTitle:  "Alfa Omega",
-				title:      "Underwater Basketweaver - Atlantic",
-				role:       role2,
-				assignment: assignment2,
-				// husd:       "455.85 HUSD",
-				// hypha:      "265.91 HYPHA",
-				// hvoice:     "3039.00 HVOICE",
-				// usd:        "1519.50 USD",
-			},
-		}
+    tests := []struct {
+      name       string
+      roleTitle  string
+      title      string
+      role       string
+      assignment string
+      husd       string
+      hypha      string
+      hvoice     string
+      usd        string
+    }{
+      {
+        name:       "role2 - 100% commit, 70% deferred",
+        roleTitle:  "Alfa Omega",
+        title:      "Underwater Basketweaver - Atlantic",
+        role:       role2,
+        assignment: assignment2,
+        // husd:       "455.85 HUSD",
+        // hypha:      "265.91 HYPHA",
+        // hvoice:     "3039.00 HVOICE",
+        // usd:        "1519.50 USD",
+      },
+    }
 
-		for _, test := range tests {
+    for _, test := range tests {
 
-			t.Log("\n\nStarting test: ", test.name)
-			role := CreateRole(t, env, proposer, proposer, test.role)
+      t.Log("\n\nStarting test: ", test.name)
+      role := CreateRole(t, env, proposer, proposer, test.role)
 
-			var assignment docgraph.Document
-			var err error
+      var assignment docgraph.Document
+      var err error
 
-			assignment, err = dao.CreateOldAssignment(t, env.ctx, &env.api, env.DAO, proposer.Member, proposer.Doc.Hash, role.Hash, env.Periods[0].Hash, assignment2)
+      assignment, err = dao.CreateOldAssignment(t, env.ctx, &env.api, env.DAO, proposer.Member, proposer.Doc.Hash, role.Hash, env.Periods[0].Hash, assignment2)
 
-			assert.NilError(t, err)
+      assert.NilError(t, err)
 
-			assert.Equal(t, assignment.Creator, proposer.Member)
+      assert.Equal(t, assignment.Creator, proposer.Member)
 
-			//Emulate voting period
-			t.Log("Waiting for a period to lapse...")
-			pause(t, env.PeriodPause, "", "Waiting...")
+      //Emulate voting period
+      t.Log("Waiting for a period to lapse...")
+      pause(t, env.PeriodPause, "", "Waiting...")
 
-			//Manually create the edges for passed assignments
-			ExecuteDocgraphCall(t, env, func() {
-				//Create edges
-				_, err = docgraph.CreateEdge(env.ctx, &env.api, env.DAO, env.DAO, proposer.Doc.Hash, assignment.Hash, eos.Name("assigned"))
+      //Manually create the edges for passed assignments
+      ExecuteDocgraphCall(t, env, func() {
+        //Create edges
+        _, err = docgraph.CreateEdge(env.ctx, &env.api, env.DAO, env.DAO, proposer.Doc.Hash, assignment.Hash, eos.Name("assigned"))
 
-				assert.NilError(t, err)
+        assert.NilError(t, err)
 
-				_, err = docgraph.CreateEdge(env.ctx, &env.api, env.DAO, env.DAO, assignment.Hash, proposer.Doc.Hash, eos.Name("assignee"))
+        _, err = docgraph.CreateEdge(env.ctx, &env.api, env.DAO, env.DAO, assignment.Hash, proposer.Doc.Hash, eos.Name("assignee"))
 
-				assert.NilError(t, err)
+        assert.NilError(t, err)
 
-				_, err = docgraph.CreateEdge(env.ctx, &env.api, env.DAO, env.DAO, role.Hash, assignment.Hash, eos.Name("assignment"))
+        _, err = docgraph.CreateEdge(env.ctx, &env.api, env.DAO, env.DAO, role.Hash, assignment.Hash, eos.Name("assignment"))
 
-				assert.NilError(t, err)
-			})
+        assert.NilError(t, err)
+      })
 
-			fv, err := assignment.GetContent("title")
-			assert.NilError(t, err)
-			assert.Equal(t, fv.String(), test.title)
+      fv, err := assignment.GetContent("title")
+      assert.NilError(t, err)
+      assert.Equal(t, fv.String(), test.title)
 
-			// verify that the edges are created correctly
-			// Graph structure post creating proposal:
-			// update graph edges:
-			//  member          ---- assigned           ---->   role_assignment
-			//  role_assignment ---- assignee           ---->   member
-			//  role_assignment ---- role               ---->   role
-			//  role            ---- role_assignment    ---->   role_assignment
-			checkEdge(t, env, proposer.Doc, assignment, eos.Name("assigned"))
-			checkEdge(t, env, assignment, proposer.Doc, eos.Name("assignee"))
-			//checkEdge(t, env, assignment, role, eos.Name("role"))
-			checkEdge(t, env, role, assignment, eos.Name("assignment"))
+      // verify that the edges are created correctly
+      // Graph structure post creating proposal:
+      // update graph edges:
+      //  member          ---- assigned           ---->   role_assignment
+      //  role_assignment ---- assignee           ---->   member
+      //  role_assignment ---- role               ---->   role
+      //  role            ---- role_assignment    ---->   role_assignment
+      checkEdge(t, env, proposer.Doc, assignment, eos.Name("assigned"))
+      checkEdge(t, env, assignment, proposer.Doc, eos.Name("assignee"))
+      //checkEdge(t, env, assignment, role, eos.Name("role"))
+      checkEdge(t, env, role, assignment, eos.Name("assignment"))
 
-			//  root ---- passedprops        ---->   role_assignment
-			//checkEdge(t, env, env.Root, assignment, eos.Name("passedprops"))
+      //  root ---- passedprops        ---->   role_assignment
+      //checkEdge(t, env, env.Root, assignment, eos.Name("passedprops"))
 
-			t.Log("Waiting for a period to lapse...")
-			pause(t, env.PeriodPause, "", "Waiting...")
+      t.Log("Waiting for a period to lapse...")
+      pause(t, env.PeriodPause, "", "Waiting...")
 
-			_, err = ClaimNextPeriod(t, env, proposer.Member, assignment)
-			assert.NilError(t, err)
+      _, err = ClaimNextPeriod(t, env, proposer.Member, assignment)
+      assert.NilError(t, err)
 
-			// Assignment hash will change due origina_approved_date item begin added the first time
-			// we claim with an old assignment
-			assignment, err = docgraph.GetLastDocumentOfEdge(env.ctx, &env.api, env.DAO, eos.Name("assignment"))
-			assert.NilError(t, err)
+      // Assignment hash will change due origina_approved_date item begin added the first time
+      // we claim with an old assignment
+      assignment, err = docgraph.GetLastDocumentOfEdge(env.ctx, &env.api, env.DAO, eos.Name("assignment"))
+      assert.NilError(t, err)
 
-			fetchedAssignment, err := docgraph.GetLastDocumentOfEdge(env.ctx, &env.api, env.DAO, eos.Name("assignment"))
+      fetchedAssignment, err := docgraph.GetLastDocumentOfEdge(env.ctx, &env.api, env.DAO, eos.Name("assignment"))
 
-			husd, err := fetchedAssignment.GetContent("husd_salary_per_phase")
-			assert.NilError(t, err)
-			hypha, err := fetchedAssignment.GetContent("hypha_salary_per_phase")
+      husd, err := fetchedAssignment.GetContent("husd_salary_per_phase")
+      assert.NilError(t, err)
+      hypha, err := fetchedAssignment.GetContent("hypha_salary_per_phase")
 
-			assert.NilError(t, err)
+      assert.NilError(t, err)
 
-			hvoice, err := fetchedAssignment.GetContent("hvoice_salary_per_phase")
-			assert.NilError(t, err)
+      hvoice, err := fetchedAssignment.GetContent("hvoice_salary_per_phase")
+      assert.NilError(t, err)
 
-			var payments []Balance
-			// first payment is a partial payment, so should be less than the amount on the assignment record
-			payments = append(payments, CalcLastPayment(t, env, balances[len(balances)-1], proposer.Member))
-			balances = append(balances, GetBalance(t, env, proposer.Member))
-			assert.Assert(t, hypha.Impl.(eos.Asset).Amount >= payments[len(payments)-1].Hypha.Amount)
-			assert.Assert(t, husd.Impl.(eos.Asset).Amount >= payments[len(payments)-1].Husd.Amount)
-			t.Log("Hvoice from payment      : ", strconv.Itoa(int(payments[len(payments)-1].Hvoice.Amount)))
-			t.Log("Hvoice from assignment   : ", strconv.Itoa(int(hvoice.Impl.(eos.Asset).Amount)))
-			assert.Assert(t, hvoice.Impl.(eos.Asset).Amount+eos.Int64(env.GenesisHVOICE) >= payments[len(payments)-1].Hvoice.Amount)
-			//No seeds payment anymore
-			//assert.Assert(t, payments[len(payments)-1].SeedsEscrow.Amount > 0)
+      var payments []Balance
+      // first payment is a partial payment, so should be less than the amount on the assignment record
+      payments = append(payments, CalcLastPayment(t, env, balances[len(balances)-1], proposer.Member))
+      balances = append(balances, GetBalance(t, env, proposer.Member))
+      assert.Assert(t, hypha.Impl.(eos.Asset).Amount >= payments[len(payments)-1].Hypha.Amount)
+      assert.Assert(t, husd.Impl.(eos.Asset).Amount >= payments[len(payments)-1].Husd.Amount)
+      t.Log("Hvoice from payment      : ", strconv.Itoa(int(payments[len(payments)-1].Hvoice.Amount)))
+      t.Log("Hvoice from assignment   : ", strconv.Itoa(int(hvoice.Impl.(eos.Asset).Amount)))
+      assert.Assert(t, hvoice.Impl.(eos.Asset).Amount+eos.Int64(env.GenesisHVOICE) >= payments[len(payments)-1].Hvoice.Amount)
+      //No seeds payment anymore
+      //assert.Assert(t, payments[len(payments)-1].SeedsEscrow.Amount > 0)
 
-			t.Log("Waiting for a period to lapse...")
-			pause(t, env.PeriodPause, "", "Waiting...")
+      t.Log("Waiting for a period to lapse...")
+      pause(t, env.PeriodPause, "", "Waiting...")
 
-			_, err = ClaimNextPeriod(t, env, proposer.Member, assignment)
-			assert.NilError(t, err)
+      _, err = ClaimNextPeriod(t, env, proposer.Member, assignment)
+      assert.NilError(t, err)
 
-			// 2nd payment should be equal to the payment on the assignment record
-			payments = append(payments, CalcLastPayment(t, env, balances[len(balances)-1], proposer.Member))
-			balances = append(balances, GetBalance(t, env, proposer.Member))
-			assert.Equal(t, hypha.Impl.(eos.Asset).Amount, payments[len(payments)-1].Hypha.Amount)
-			assert.Equal(t, husd.Impl.(eos.Asset).Amount, payments[len(payments)-1].Husd.Amount)
-			assert.Equal(t, hvoice.Impl.(eos.Asset).Amount, payments[len(payments)-1].Hvoice.Amount)
-			//assert.Assert(t, payments[len(payments)-1].SeedsEscrow.Amount >= payments[len(payments)-2].SeedsEscrow.Amount)
-		}
-	})
+      // 2nd payment should be equal to the payment on the assignment record
+      payments = append(payments, CalcLastPayment(t, env, balances[len(balances)-1], proposer.Member))
+      balances = append(balances, GetBalance(t, env, proposer.Member))
+      assert.Equal(t, hypha.Impl.(eos.Asset).Amount, payments[len(payments)-1].Hypha.Amount)
+      assert.Equal(t, husd.Impl.(eos.Asset).Amount, payments[len(payments)-1].Husd.Amount)
+      assert.Equal(t, hvoice.Impl.(eos.Asset).Amount, payments[len(payments)-1].Hvoice.Amount)
+      //assert.Assert(t, payments[len(payments)-1].SeedsEscrow.Amount >= payments[len(payments)-2].SeedsEscrow.Amount)
+    }
+  })
 }
 
 func TestAssignmentPayClaim(t *testing.T) {
-	teardownTestCase := setupTestCase(t)
-	defer teardownTestCase(t)
+  teardownTestCase := setupTestCase(t)
+  defer teardownTestCase(t)
 
-	env = SetupEnvironment(t)
-	t.Log(env.String())
-	t.Log("\nDAO Environment Setup complete\n")
+  env = SetupEnvironment(t)
+  t.Log(env.String())
+  t.Log("\nDAO Environment Setup complete\n")
 
-	balances = append(balances, NewBalance())
+  balances = append(balances, NewBalance())
 
-	// roles
-	proposer := env.Members[0]
-	assignee := env.Members[1]
-	closer := env.Members[2]
+  // roles
+  proposer := env.Members[0]
+  assignee := env.Members[1]
+  closer := env.Members[2]
 
-	t.Run("Test Assignment Pay Claim", func(t *testing.T) {
+  t.Run("Test Assignment Pay Claim", func(t *testing.T) {
 
-		tests := []struct {
-			name       string
-			roleTitle  string
-			title      string
-			role       string
-			assignment string
-			husd       string
-			hypha      string
-			hvoice     string
-			usd        string
-		}{
-			{
-				name:       "role2 - 100% commit, 70% deferred",
-				roleTitle:  "Underwater Basketweaver",
-				title:      "Underwater Basketweaver - Atlantic",
-				role:       role2,
-				assignment: assignment2,
-				// husd:       "455.85 HUSD",
-				// hypha:      "265.91 HYPHA",
-				// hvoice:     "3039.00 HVOICE",
-				// usd:        "1519.50 USD",
-			},
-		}
+    tests := []struct {
+      name       string
+      roleTitle  string
+      title      string
+      role       string
+      assignment string
+      husd       string
+      hypha      string
+      hvoice     string
+      usd        string
+    }{
+      {
+        name:       "role2 - 100% commit, 70% deferred",
+        roleTitle:  "Underwater Basketweaver",
+        title:      "Underwater Basketweaver - Atlantic",
+        role:       role2,
+        assignment: assignment2,
+        // husd:       "455.85 HUSD",
+        // hypha:      "265.91 HYPHA",
+        // hvoice:     "3039.00 HVOICE",
+        // usd:        "1519.50 USD",
+      },
+    }
 
-		for _, test := range tests {
+    for _, test := range tests {
 
-			t.Log("\n\nStarting test: ", test.name)
-			role := CreateRole(t, env, proposer, closer, test.role)
+      t.Log("\n\nStarting test: ", test.name)
+      role := CreateRole(t, env, proposer, closer, test.role)
 
-			trxID, err := dao.ProposeAssignment(env.ctx, &env.api, env.DAO, proposer.Member, assignee.Member, role.Hash, env.Periods[0].Hash, test.assignment)
-			t.Log("Assignment proposed: ", trxID)
-			assert.NilError(t, err)
+      trxID, err := dao.ProposeAssignment(env.ctx, &env.api, env.DAO, proposer.Member, assignee.Member, role.Hash, env.Periods[0].Hash, test.assignment)
+      t.Log("Assignment proposed: ", trxID)
+      assert.NilError(t, err)
 
-			// retrieve the document we just created
-			assignment, err := docgraph.GetLastDocumentOfEdge(env.ctx, &env.api, env.DAO, eos.Name("proposal"))
-			assert.NilError(t, err)
-			assert.Equal(t, assignment.Creator, proposer.Member)
+      // retrieve the document we just created
+      assignment, err := docgraph.GetLastDocumentOfEdge(env.ctx, &env.api, env.DAO, eos.Name("proposal"))
+      assert.NilError(t, err)
+      assert.Equal(t, assignment.Creator, proposer.Member)
 
-			fv, err := assignment.GetContent("title")
-			assert.NilError(t, err)
-			assert.Equal(t, fv.String(), test.title)
+      fv, err := assignment.GetContent("title")
+      assert.NilError(t, err)
+      assert.Equal(t, fv.String(), test.title)
 
-			// verify that the edges are created correctly
-			// Graph structure post creating proposal:
-			// root 		---proposal---> 	propDocument
-			// member 		---owns-------> 	propDocument
-			// propDocument ---ownedby----> 	member
-			checkEdge(t, env, env.Root, assignment, eos.Name("proposal"))
-			checkEdge(t, env, proposer.Doc, assignment, eos.Name("owns"))
-			checkEdge(t, env, assignment, proposer.Doc, eos.Name("ownedby"))
+      // verify that the edges are created correctly
+      // Graph structure post creating proposal:
+      // root 		---proposal---> 	propDocument
+      // member 		---owns-------> 	propDocument
+      // propDocument ---ownedby----> 	member
+      checkEdge(t, env, env.Root, assignment, eos.Name("proposal"))
+      checkEdge(t, env, proposer.Doc, assignment, eos.Name("owns"))
+      checkEdge(t, env, assignment, proposer.Doc, eos.Name("ownedby"))
 
-			voteToPassTD(t, env, assignment)
+      voteToPassTD(t, env, assignment)
 
-			t.Log("Member: ", closer.Member, " is closing assignment proposal	: ", assignment.Hash.String())
-			_, err = dao.CloseProposal(env.ctx, &env.api, env.DAO, closer.Member, assignment.Hash)
-			assert.NilError(t, err)
+      t.Log("Member: ", closer.Member, " is closing assignment proposal	: ", assignment.Hash.String())
+      _, err = dao.CloseProposal(env.ctx, &env.api, env.DAO, closer.Member, assignment.Hash)
+      assert.NilError(t, err)
 
-			// verify that the edges are created correctly
-			// Graph structure post creating proposal:
-			// update graph edges:
-			//  member          ---- assigned           ---->   role_assignment
-			//  role_assignment ---- assignee           ---->   member
-			//  role_assignment ---- role               ---->   role
-			//  role            ---- role_assignment    ---->   role_assignment
-			checkEdge(t, env, assignee.Doc, assignment, eos.Name("assigned"))
-			checkEdge(t, env, assignment, assignee.Doc, eos.Name("assignee"))
-			checkEdge(t, env, assignment, role, eos.Name("role"))
-			checkEdge(t, env, role, assignment, eos.Name("assignment"))
+      // verify that the edges are created correctly
+      // Graph structure post creating proposal:
+      // update graph edges:
+      //  member          ---- assigned           ---->   role_assignment
+      //  role_assignment ---- assignee           ---->   member
+      //  role_assignment ---- role               ---->   role
+      //  role            ---- role_assignment    ---->   role_assignment
+      checkEdge(t, env, assignee.Doc, assignment, eos.Name("assigned"))
+      checkEdge(t, env, assignment, assignee.Doc, eos.Name("assignee"))
+      checkEdge(t, env, assignment, role, eos.Name("role"))
+      checkEdge(t, env, role, assignment, eos.Name("assignment"))
 
-			//  root ---- passedprops        ---->   role_assignment
-			checkEdge(t, env, env.Root, assignment, eos.Name("passedprops"))
+      //  root ---- passedprops        ---->   role_assignment
+      checkEdge(t, env, env.Root, assignment, eos.Name("passedprops"))
 
-			t.Log("Waiting for a period to lapse...")
-			pause(t, env.PeriodPause, "", "Waiting...")
+      t.Log("Waiting for a period to lapse...")
+      pause(t, env.PeriodPause, "", "Waiting...")
 
-			_, err = ClaimNextPeriod(t, env, assignee.Member, assignment)
-			assert.NilError(t, err)
+      _, err = ClaimNextPeriod(t, env, assignee.Member, assignment)
+      assert.NilError(t, err)
 
-			fetchedAssignment, err := docgraph.GetLastDocumentOfEdge(env.ctx, &env.api, env.DAO, eos.Name("assignment"))
+      fetchedAssignment, err := docgraph.GetLastDocumentOfEdge(env.ctx, &env.api, env.DAO, eos.Name("assignment"))
 
-			husd, err := fetchedAssignment.GetContent("husd_salary_per_phase")
-			assert.NilError(t, err)
+      husd, err := fetchedAssignment.GetContent("husd_salary_per_phase")
+      assert.NilError(t, err)
 
-			hypha, err := fetchedAssignment.GetContent("hypha_salary_per_phase")
-			assert.NilError(t, err)
+      hypha, err := fetchedAssignment.GetContent("hypha_salary_per_phase")
+      assert.NilError(t, err)
 
-			hvoice, err := fetchedAssignment.GetContent("hvoice_salary_per_phase")
-			assert.NilError(t, err)
+      hvoice, err := fetchedAssignment.GetContent("hvoice_salary_per_phase")
+      assert.NilError(t, err)
 
-			// first payment is a partial payment, so should be less than the amount on the assignment record
-			// SEEDS escrow payment should be greater than zero
-			payments = append(payments, CalcLastPayment(t, env, balances[len(balances)-1], assignee.Member))
-			balances = append(balances, GetBalance(t, env, assignee.Member))
-			assert.Assert(t, hypha.Impl.(eos.Asset).Amount >= payments[len(payments)-1].Hypha.Amount)
-			assert.Assert(t, husd.Impl.(eos.Asset).Amount >= payments[len(payments)-1].Husd.Amount)
-			t.Log("Hvoice from payment      : ", strconv.Itoa(int(payments[len(payments)-1].Hvoice.Amount)))
-			t.Log("Hvoice from assignment   : ", strconv.Itoa(int(hvoice.Impl.(eos.Asset).Amount)))
-			assert.Assert(t, hvoice.Impl.(eos.Asset).Amount+eos.Int64(env.GenesisHVOICE) >= payments[len(payments)-1].Hvoice.Amount)
-			assert.Assert(t, payments[len(payments)-1].SeedsEscrow.Amount > 0)
+      // first payment is a partial payment, so should be less than the amount on the assignment record
+      // SEEDS escrow payment should be greater than zero
+      payments = append(payments, CalcLastPayment(t, env, balances[len(balances)-1], assignee.Member))
+      balances = append(balances, GetBalance(t, env, assignee.Member))
+      assert.Assert(t, hypha.Impl.(eos.Asset).Amount >= payments[len(payments)-1].Hypha.Amount)
+      assert.Assert(t, husd.Impl.(eos.Asset).Amount >= payments[len(payments)-1].Husd.Amount)
+      t.Log("Hvoice from payment      : ", strconv.Itoa(int(payments[len(payments)-1].Hvoice.Amount)))
+      t.Log("Hvoice from assignment   : ", strconv.Itoa(int(hvoice.Impl.(eos.Asset).Amount)))
+      assert.Assert(t, hvoice.Impl.(eos.Asset).Amount+eos.Int64(env.GenesisHVOICE) >= payments[len(payments)-1].Hvoice.Amount)
+      assert.Assert(t, payments[len(payments)-1].SeedsEscrow.Amount > 0)
 
-			t.Log("Waiting for a period to lapse...")
-			pause(t, env.PeriodPause, "", "Waiting...")
+      t.Log("Waiting for a period to lapse...")
+      pause(t, env.PeriodPause, "", "Waiting...")
 
-			_, err = ClaimNextPeriod(t, env, assignee.Member, assignment)
-			assert.NilError(t, err)
+      _, err = ClaimNextPeriod(t, env, assignee.Member, assignment)
+      assert.NilError(t, err)
 
-			// 2nd payment should be equal to the payment on the assignment record
-			// 2nd SEEDS escrow payment should be greater than the first one
-			payments = append(payments, CalcLastPayment(t, env, balances[len(balances)-1], assignee.Member))
-			balances = append(balances, GetBalance(t, env, assignee.Member))
-			assert.Equal(t, hypha.Impl.(eos.Asset).Amount, payments[len(payments)-1].Hypha.Amount)
-			assert.Equal(t, husd.Impl.(eos.Asset).Amount, payments[len(payments)-1].Husd.Amount)
-			assert.Equal(t, hvoice.Impl.(eos.Asset).Amount, payments[len(payments)-1].Hvoice.Amount)
-			assert.Assert(t, payments[len(payments)-1].SeedsEscrow.Amount >= payments[len(payments)-2].SeedsEscrow.Amount)
-		}
-	})
+      // 2nd payment should be equal to the payment on the assignment record
+      // 2nd SEEDS escrow payment should be greater than the first one
+      payments = append(payments, CalcLastPayment(t, env, balances[len(balances)-1], assignee.Member))
+      balances = append(balances, GetBalance(t, env, assignee.Member))
+      assert.Equal(t, hypha.Impl.(eos.Asset).Amount, payments[len(payments)-1].Hypha.Amount)
+      assert.Equal(t, husd.Impl.(eos.Asset).Amount, payments[len(payments)-1].Husd.Amount)
+      assert.Equal(t, hvoice.Impl.(eos.Asset).Amount, payments[len(payments)-1].Hvoice.Amount)
+      assert.Assert(t, payments[len(payments)-1].SeedsEscrow.Amount >= payments[len(payments)-2].SeedsEscrow.Amount)
+    }
+  })
 }
 
 func TestAssignmentExtensionProposal(t *testing.T) {
-	teardownTestCase := setupTestCase(t)
-	defer teardownTestCase(t)
+  teardownTestCase := setupTestCase(t)
+  defer teardownTestCase(t)
 
-	env = SetupEnvironment(t)
-	t.Log(env.String())
-	t.Log("\nDAO Environment Setup complete\n")
+  env = SetupEnvironment(t)
+  t.Log(env.String())
+  t.Log("\nDAO Environment Setup complete\n")
 
-	balances = append(balances, NewBalance())
+  balances = append(balances, NewBalance())
 
-	// roles
-	proposer := env.Members[0]
-	assignee := env.Members[0]
-	closer := env.Members[0]
+  // roles
+  proposer := env.Members[0]
+  assignee := env.Members[0]
+  closer := env.Members[0]
 
-	t.Run("Test Assignment Extension", func(t *testing.T) {
+  t.Run("Test Assignment Extension", func(t *testing.T) {
 
-		tests := []struct {
-			name       string
-			roleTitle  string
-			title      string
-			role       string
-			assignment string
-			husd       string
-			hypha      string
-			hvoice     string
-			usd        string
-		}{
-			{
-				name:       "role2 - 100% commit, 70% deferred",
-				roleTitle:  "Underwater Basketweaver",
-				title:      "Underwater Basketweaver - Atlantic",
-				role:       role2,
-				assignment: assignment2,
-				// husd:       "455.85 HUSD",
-				// hypha:      "265.91 HYPHA",
-				// hvoice:     "3039.00 HVOICE",
-				// usd:        "1519.50 USD",
-			},
-		}
+    tests := []struct {
+      name       string
+      roleTitle  string
+      title      string
+      role       string
+      assignment string
+      husd       string
+      hypha      string
+      hvoice     string
+      usd        string
+    }{
+      {
+        name:       "role2 - 100% commit, 70% deferred",
+        roleTitle:  "Underwater Basketweaver",
+        title:      "Underwater Basketweaver - Atlantic",
+        role:       role2,
+        assignment: assignment2,
+        // husd:       "455.85 HUSD",
+        // hypha:      "265.91 HYPHA",
+        // hvoice:     "3039.00 HVOICE",
+        // usd:        "1519.50 USD",
+      },
+    }
 
-		for _, test := range tests {
+    for _, test := range tests {
 
-			t.Log("\n\nStarting test: ", test.name)
-			role := CreateRole(t, env, proposer, closer, test.role)
+      t.Log("\n\nStarting test: ", test.name)
+      role := CreateRole(t, env, proposer, closer, test.role)
 
-			trxID, err := dao.ProposeAssignment(env.ctx, &env.api, env.DAO, proposer.Member, assignee.Member, role.Hash, env.Periods[0].Hash, test.assignment)
-			t.Log("Assignment proposed: ", trxID)
-			assert.NilError(t, err)
+      trxID, err := dao.ProposeAssignment(env.ctx, &env.api, env.DAO, proposer.Member, assignee.Member, role.Hash, env.Periods[0].Hash, test.assignment)
+      t.Log("Assignment proposed: ", trxID)
+      assert.NilError(t, err)
 
-			// retrieve the document we just created
-			assignment, err := docgraph.GetLastDocumentOfEdge(env.ctx, &env.api, env.DAO, eos.Name("proposal"))
-			assert.NilError(t, err)
-			assert.Equal(t, assignment.Creator, proposer.Member)
+      // retrieve the document we just created
+      assignment, err := docgraph.GetLastDocumentOfEdge(env.ctx, &env.api, env.DAO, eos.Name("proposal"))
+      assert.NilError(t, err)
+      assert.Equal(t, assignment.Creator, proposer.Member)
 
-			fv, err := assignment.GetContent("title")
-			assert.NilError(t, err)
-			assert.Equal(t, fv.String(), test.title)
+      fv, err := assignment.GetContent("title")
+      assert.NilError(t, err)
+      assert.Equal(t, fv.String(), test.title)
 
-			originalPeriodCount, err := assignment.GetContent("period_count")
-			assert.NilError(t, err)
+      originalPeriodCount, err := assignment.GetContent("period_count")
+      assert.NilError(t, err)
 
-			// verify that the edges are created correctly
-			// Graph structure post creating proposal:
-			// root 		---proposal---> 	propDocument
-			// member 		---owns-------> 	propDocument
-			// propDocument ---ownedby----> 	member
-			checkEdge(t, env, env.Root, assignment, eos.Name("proposal"))
-			checkEdge(t, env, proposer.Doc, assignment, eos.Name("owns"))
-			checkEdge(t, env, assignment, proposer.Doc, eos.Name("ownedby"))
+      // verify that the edges are created correctly
+      // Graph structure post creating proposal:
+      // root 		---proposal---> 	propDocument
+      // member 		---owns-------> 	propDocument
+      // propDocument ---ownedby----> 	member
+      checkEdge(t, env, env.Root, assignment, eos.Name("proposal"))
+      checkEdge(t, env, proposer.Doc, assignment, eos.Name("owns"))
+      checkEdge(t, env, assignment, proposer.Doc, eos.Name("ownedby"))
 
-			voteToPassTD(t, env, assignment)
+      voteToPassTD(t, env, assignment)
 
-			t.Log("Member: ", closer.Member, " is closing assignment proposal	: ", assignment.Hash.String())
-			_, err = dao.CloseProposal(env.ctx, &env.api, env.DAO, closer.Member, assignment.Hash)
-			assert.NilError(t, err)
+      t.Log("Member: ", closer.Member, " is closing assignment proposal	: ", assignment.Hash.String())
+      _, err = dao.CloseProposal(env.ctx, &env.api, env.DAO, closer.Member, assignment.Hash)
+      assert.NilError(t, err)
 
-			pause(t, 1000000000, "", "Waiting before fetching assignment again")
+      pause(t, 1000000000, "", "Waiting before fetching assignment again")
 
-			// Assignment hash will change due origina_approved_date item begin added the first time
-			// we claim with an old assignment
-			assignment, err = docgraph.GetLastDocumentOfEdge(env.ctx, &env.api, env.DAO, eos.Name("assignment"))
-			assert.NilError(t, err)
+      // Assignment hash will change due origina_approved_date item begin added the first time
+      // we claim with an old assignment
+      assignment, err = docgraph.GetLastDocumentOfEdge(env.ctx, &env.api, env.DAO, eos.Name("assignment"))
+      assert.NilError(t, err)
 
-			// verify that the edges are created correctly
-			// Graph structure post creating proposal:
-			// update graph edges:
-			//  member          ---- assigned           ---->   role_assignment
-			//  role_assignment ---- assignee           ---->   member
-			//  role_assignment ---- role               ---->   role
-			//  role            ---- role_assignment    ---->   role_assignment
-			checkEdge(t, env, assignee.Doc, assignment, eos.Name("assigned"))
-			checkEdge(t, env, assignment, assignee.Doc, eos.Name("assignee"))
-			checkEdge(t, env, assignment, role, eos.Name("role"))
-			checkEdge(t, env, role, assignment, eos.Name("assignment"))
+      // verify that the edges are created correctly
+      // Graph structure post creating proposal:
+      // update graph edges:
+      //  member          ---- assigned           ---->   role_assignment
+      //  role_assignment ---- assignee           ---->   member
+      //  role_assignment ---- role               ---->   role
+      //  role            ---- role_assignment    ---->   role_assignment
+      checkEdge(t, env, assignee.Doc, assignment, eos.Name("assigned"))
+      checkEdge(t, env, assignment, assignee.Doc, eos.Name("assignee"))
+      checkEdge(t, env, assignment, role, eos.Name("role"))
+      checkEdge(t, env, role, assignment, eos.Name("assignment"))
 
-			//  root ---- passedprops        ---->   role_assignment
-			checkEdge(t, env, env.Root, assignment, eos.Name("passedprops"))
+      //  root ---- passedprops        ---->   role_assignment
+      checkEdge(t, env, env.Root, assignment, eos.Name("passedprops"))
 
-			trxID, err = dao.ProposeAssExtension(env.ctx, &env.api, env.DAO, assignee.Member, assignment.Hash.String(), 13)
-			assert.NilError(t, err)
+      trxID, err = dao.ProposeAssExtension(env.ctx, &env.api, env.DAO, assignee.Member, assignment.Hash.String(), 13)
+      assert.NilError(t, err)
 
-			// retrieve the document we just created
-			extensionProp, err := docgraph.GetLastDocumentOfEdge(env.ctx, &env.api, env.DAO, eos.Name("proposal"))
-			assert.NilError(t, err)
-			assert.Equal(t, extensionProp.Creator, proposer.Member)
+      // retrieve the document we just created
+      extensionProp, err := docgraph.GetLastDocumentOfEdge(env.ctx, &env.api, env.DAO, eos.Name("proposal"))
+      assert.NilError(t, err)
+      assert.Equal(t, extensionProp.Creator, proposer.Member)
 
-			voteToPassTD(t, env, extensionProp)
+      voteToPassTD(t, env, extensionProp)
 
-			t.Log("Member: ", closer.Member, " is closing extension proposal	: ", extensionProp.Hash.String())
-			_, err = dao.CloseProposal(env.ctx, &env.api, env.DAO, closer.Member, extensionProp.Hash)
-			assert.NilError(t, err)
+      t.Log("Member: ", closer.Member, " is closing extension proposal	: ", extensionProp.Hash.String())
+      _, err = dao.CloseProposal(env.ctx, &env.api, env.DAO, closer.Member, extensionProp.Hash)
+      assert.NilError(t, err)
 
-			originalPeriodCountValue, err := originalPeriodCount.Int64()
-			assert.NilError(t, err)
+      originalPeriodCountValue, err := originalPeriodCount.Int64()
+      assert.NilError(t, err)
 
-			newPeriodCount, err := extensionProp.GetContent("period_count")
-			assert.NilError(t, err)
+      newPeriodCount, err := extensionProp.GetContent("period_count")
+      assert.NilError(t, err)
 
-			newPeriodCountValue, err := newPeriodCount.Int64()
-			assert.NilError(t, err)
+      newPeriodCountValue, err := newPeriodCount.Int64()
+      assert.NilError(t, err)
 
-			assert.Equal(t, originalPeriodCountValue+13, newPeriodCountValue)
-		}
-	})
+      assert.Equal(t, originalPeriodCountValue+13, newPeriodCountValue)
+    }
+  })
 }
 
 func TestAssignmentEditProposal(t *testing.T) {
-	teardownTestCase := setupTestCase(t)
-	defer teardownTestCase(t)
+  teardownTestCase := setupTestCase(t)
+  defer teardownTestCase(t)
 
-	env = SetupEnvironment(t)
-	t.Log(env.String())
-	t.Log("\nDAO Environment Setup complete\n")
+	//20 Periods
 
-	balances = append(balances, NewBalance())
+  env = SetupEnvironment(t)
+  t.Log(env.String())
+  t.Log("\nDAO Environment Setup complete\n")
 
-	// roles
-	proposer := env.Members[0]
-	assignee := env.Members[0]
-	closer := env.Members[0]
+  balances = append(balances, NewBalance())
 
-	t.Run("Test Assignment Edit", func(t *testing.T) {
+  // roles
+  proposer := env.Members[0]
+  assignee := env.Members[0]
+  closer := env.Members[0]
 
-		tests := []struct {
-			name       string
-			roleTitle  string
-			title      string
-			role       string
-			assignment string
-			edit       string
-			failedit   string
-			husd       string
-			hypha      string
-			hvoice     string
-			usd        string
-		}{
-			{
-				name:       "role2 - 100% commit, 70% deferred",
-				roleTitle:  "Underwater Basketweaver",
-				title:      "Underwater Basketweaver - Atlantic",
-				role:       role2,
-				assignment: assignment2,
-				edit:       assignment2_edit,
-				failedit:   fail_assignment2_edit,
-				// husd:       "455.85 HUSD",
-				// hypha:      "265.91 HYPHA",
-				// hvoice:     "3039.00 HVOICE",
-				// usd:        "1519.50 USD",
-			},
-		}
+  t.Run("Test Assignment Edit", func(t *testing.T) {
 
-		for _, test := range tests {
+    tests := []struct {
+      name       string
+      roleTitle  string
+      title      string
+      role       string
+      assignment string
+      edit       string
+      failedit   string
+      husd       string
+      hypha      string
+      hvoice     string
+      usd        string
+    }{
+      {
+        name:       "role2 - 100% commit, 70% deferred",
+        roleTitle:  "Underwater Basketweaver",
+        title:      "Underwater Basketweaver - Atlantic",
+        role:       role2,
+        assignment: assignment2,
+        edit:       assignment2_edit,
+        failedit:   fail_assignment2_edit,
+        // husd:       "455.85 HUSD",
+        // hypha:      "265.91 HYPHA",
+        // hvoice:     "3039.00 HVOICE",
+        // usd:        "1519.50 USD",
+      },
+    }
 
-			t.Log("\n\nStarting test: ", test.name)
-			role := CreateRole(t, env, proposer, closer, test.role)
+    for _, test := range tests {
 
-			trxID, err := dao.ProposeAssignment(env.ctx, &env.api, env.DAO, proposer.Member, assignee.Member, role.Hash, env.Periods[0].Hash, test.assignment)
-			t.Log("Assignment proposed: ", trxID)
-			assert.NilError(t, err)
+      t.Log("\n\nStarting test: ", test.name)
+      role := CreateRole(t, env, proposer, closer, test.role)
 
-			// retrieve the document we just created
-			assignment, err := docgraph.GetLastDocumentOfEdge(env.ctx, &env.api, env.DAO, eos.Name("proposal"))
-			assert.NilError(t, err)
-			assert.Equal(t, assignment.Creator, proposer.Member)
+      trxID, err := dao.ProposeAssignment(env.ctx, &env.api, env.DAO, proposer.Member, assignee.Member, role.Hash, env.Periods[0].Hash, test.assignment)
+      t.Log("Assignment proposed: ", trxID)
+      assert.NilError(t, err)
 
-			fv, err := assignment.GetContent("title")
-			assert.NilError(t, err)
-			assert.Equal(t, fv.String(), test.title)
+      // retrieve the document we just created
+      assignment, err := docgraph.GetLastDocumentOfEdge(env.ctx, &env.api, env.DAO, eos.Name("proposal"))
+      assert.NilError(t, err)
+      assert.Equal(t, assignment.Creator, proposer.Member)
 
-			originalPeriodCount, err := assignment.GetContent("period_count")
-			assert.NilError(t, err)
-			assert.Equal(t, originalPeriodCount.Impl.(int64), int64(10))
+      fv, err := assignment.GetContent("title")
+      assert.NilError(t, err)
+      assert.Equal(t, fv.String(), test.title)
 
-			// verify that the edges are created correctly
-			// Graph structure post creating proposal:
-			// root 		---proposal---> 	propDocument
-			// member 		---owns-------> 	propDocument
-			// propDocument ---ownedby----> 	member
-			checkEdge(t, env, env.Root, assignment, eos.Name("proposal"))
-			checkEdge(t, env, proposer.Doc, assignment, eos.Name("owns"))
-			checkEdge(t, env, assignment, proposer.Doc, eos.Name("ownedby"))
+      originalPeriodCount, err := assignment.GetContent("period_count")
+      assert.NilError(t, err)
+      assert.Equal(t, originalPeriodCount.Impl.(int64), int64(10))
 
-			voteToPassTD(t, env, assignment)
+      // verify that the edges are created correctly
+      // Graph structure post creating proposal:
+      // root 		---proposal---> 	propDocument
+      // member 		---owns-------> 	propDocument
+      // propDocument ---ownedby----> 	member
+      checkEdge(t, env, env.Root, assignment, eos.Name("proposal"))
+      checkEdge(t, env, proposer.Doc, assignment, eos.Name("owns"))
+      checkEdge(t, env, assignment, proposer.Doc, eos.Name("ownedby"))
 
-			t.Log("Member: ", closer.Member, " is closing assignment proposal	: ", assignment.Hash.String())
-			_, err = dao.CloseProposal(env.ctx, &env.api, env.DAO, closer.Member, assignment.Hash)
-			assert.NilError(t, err)
+      voteToPassTD(t, env, assignment)
 
-			pause(t, 1000000000, "", "Waiting before fetching assignment again")
+      t.Log("Member: ", closer.Member, " is closing assignment proposal	: ", assignment.Hash.String())
+      _, err = dao.CloseProposal(env.ctx, &env.api, env.DAO, closer.Member, assignment.Hash)
+      assert.NilError(t, err)
 
-			// Assignment hash will change due origina_approved_date item begin added the first time
-			// we claim with an old assignment
-			assignment, err = docgraph.GetLastDocumentOfEdge(env.ctx, &env.api, env.DAO, eos.Name("assignment"))
-			assert.NilError(t, err)
+      pause(t, 1000000000, "", "Waiting before fetching assignment again")
 
-			// verify that the edges are created correctly
-			// Graph structure post creating proposal:
-			// update graph edges:
-			//  member          ---- assigned           ---->   role_assignment
-			//  role_assignment ---- assignee           ---->   member
-			//  role_assignment ---- role               ---->   role
-			//  role            ---- role_assignment    ---->   role_assignment
-			checkEdge(t, env, assignee.Doc, assignment, eos.Name("assigned"))
-			checkEdge(t, env, assignment, assignee.Doc, eos.Name("assignee"))
-			checkEdge(t, env, assignment, role, eos.Name("role"))
-			checkEdge(t, env, role, assignment, eos.Name("assignment"))
+      // Assignment hash will change due origina_approved_date item begin added the first time
+      // we claim with an old assignment
+      assignment, err = docgraph.GetLastDocumentOfEdge(env.ctx, &env.api, env.DAO, eos.Name("assignment"))
+      assert.NilError(t, err)
 
-			//  root ---- passedprops        ---->   role_assignment
-			checkEdge(t, env, env.Root, assignment, eos.Name("passedprops"))
+      // verify that the edges are created correctly
+      // Graph structure post creating proposal:
+      // update graph edges:
+      //  member          ---- assigned           ---->   role_assignment
+      //  role_assignment ---- assignee           ---->   member
+      //  role_assignment ---- role               ---->   role
+      //  role            ---- role_assignment    ---->   role_assignment
+      checkEdge(t, env, assignee.Doc, assignment, eos.Name("assigned"))
+      checkEdge(t, env, assignment, assignee.Doc, eos.Name("assignee"))
+      checkEdge(t, env, assignment, role, eos.Name("role"))
+      checkEdge(t, env, role, assignment, eos.Name("assignment"))
 
-			trxID, err = dao.ProposeEdit(env.ctx, &env.api, env.DAO, assignee.Member, assignment, test.edit)
-			assert.NilError(t, err)
+      //  root ---- passedprops        ---->   role_assignment
+      checkEdge(t, env, env.Root, assignment, eos.Name("passedprops"))
 
-			// retrieve the document we just created
-			editProp, err := docgraph.GetLastDocumentOfEdge(env.ctx, &env.api, env.DAO, eos.Name("proposal"))
-			assert.NilError(t, err)
-			assert.Equal(t, editProp.Creator, proposer.Member)
+      trxID, err = dao.ProposeEdit(env.ctx, &env.api, env.DAO, assignee.Member, assignment, test.edit)
+      assert.NilError(t, err)
 
-			voteToPassTD(t, env, editProp)
+      // retrieve the document we just created
+      editProp, err := docgraph.GetLastDocumentOfEdge(env.ctx, &env.api, env.DAO, eos.Name("proposal"))
+      assert.NilError(t, err)
+      assert.Equal(t, editProp.Creator, proposer.Member)
 
-			t.Log("Member: ", closer.Member, " is closing extension proposal	: ", editProp.Hash.String())
-			_, err = dao.CloseProposal(env.ctx, &env.api, env.DAO, closer.Member, editProp.Hash)
-			assert.NilError(t, err)
+      voteToPassTD(t, env, editProp)
 
-			pause(t, 1000000000, "", "Waiting before fetching assignment again")
+      t.Log("Member: ", closer.Member, " is closing extension proposal	: ", editProp.Hash.String())
+      _, err = dao.CloseProposal(env.ctx, &env.api, env.DAO, closer.Member, editProp.Hash)
+      assert.NilError(t, err)
 
-			assignment, err = docgraph.GetLastDocumentOfEdge(env.ctx, &env.api, env.DAO, eos.Name("assignment"))
-			assert.NilError(t, err)
+      pause(t, 1000000000, "", "Waiting before fetching assignment again")
 
-			newPeriodCount, err := editProp.GetContent("period_count")
-			assert.NilError(t, err)
+      assignment, err = docgraph.GetLastDocumentOfEdge(env.ctx, &env.api, env.DAO, eos.Name("assignment"))
+      assert.NilError(t, err)
 
-			newPeriodCountValue, err := newPeriodCount.Int64()
-			assert.NilError(t, err)
+      newPeriodCount, err := editProp.GetContent("period_count")
+      assert.NilError(t, err)
 
-			assert.Equal(t, int64(12), newPeriodCountValue)
+      newPeriodCountValue, err := newPeriodCount.Int64()
+      assert.NilError(t, err)
 
-			pause(t, 10*env.PeriodPause, "", "Waiting before fetching assignment again")
+      assert.Equal(t, int64(12), newPeriodCountValue)
 
-			//Wait for all the periods to finish
-			//Should fail since this assignment is now expired
-			trxID, err = dao.ProposeEdit(env.ctx, &env.api, env.DAO, assignee.Member, assignment, test.failedit)
-			assert.ErrorContains(t, err, "There has to be at least 1 remaining period before editing an assignment")
-		}
-	})
+      pause(t, time.Duration(newPeriodCountValue)*env.PeriodPause, "", "Waiting before fetching assignment again")
+
+      //Wait for all the periods to finish
+      //Should fail since this assignment is now expired
+      trxID, err = dao.ProposeEdit(env.ctx, &env.api, env.DAO, assignee.Member, assignment, test.failedit)
+      assert.ErrorContains(t, err, "There has to be at least 1 remaining period before editing/extending an assignment")
+    }
+  })
 }
 
 const base_assigment_adjust_x1 = `
@@ -1581,80 +1910,87 @@ const assignment8 = `{
 
 const assignment2_edit = `
 {
-	"content_groups": [
-			[
-					{
-							"label": "content_group_label",
-							"value": [
-									"string",
-									"details"
-							]
-					},
-					{
-							"label": "title",
-							"value": [
-									"string",
-									"Edited title"
-							]
-					},
-					{
-							"label": "description",
-							"value": [
-									"string",
-									"New description"
-							]
-					},
-					{
-						"label": "ballot_title",
-							"value": [
-									"string",
-									"Proposal to edit xxxx"
-						]
-					},
-					{
-						"label": "ballot_description",
-							"value": [
-									"string",
-									"Description of the proposal"
-						]
-					},
-					{
-							"label": "period_count",
-							"value": [
-									"int64",
-									12
-							]
-					}
-			]
-	]
+  "content_groups": [
+      [
+          {
+              "label": "content_group_label",
+              "value": [
+                  "string",
+                  "details"
+              ]
+          },
+          {
+              "label": "title",
+              "value": [
+                  "string",
+                  "Edited title"
+              ]
+          },
+          {
+              "label": "description",
+              "value": [
+                  "string",
+                  "New description"
+              ]
+          },
+          {
+            "label": "ballot_title",
+              "value": [
+                  "string",
+                  "Proposal to edit xxxx"
+            ]
+          },
+          {
+            "label": "ballot_description",
+              "value": [
+                  "string",
+                  "Description of the proposal"
+            ]
+          },
+          {
+              "label": "period_count",
+              "value": [
+                  "int64",
+                  12
+              ]
+          }
+      ]
+  ]
 }
 `
 const fail_assignment2_edit = `
 {
-	"content_groups": [
-			[
+  "content_groups": [
+      [
+          {
+              "label": "content_group_label",
+              "value": [
+                  "string",
+                  "details"
+              ]
+          },
+          {
+              "label": "ballot_title",
+              "value": [
+                  "string",
+                  "Extend assignment periods"
+              ]
+          },
 					{
-							"label": "content_group_label",
-							"value": [
-									"string",
-									"details"
-							]
-					},
-					{
-							"label": "ballot_title",
-							"value": [
-									"string",
-									"Extend assignment periods"
-							]
-					},
-					{
-							"label": "period_count",
-							"value": [
-									"int64",
-									28
-							]
-					}
-			]
-	]
+            "label": "ballot_description",
+              "value": [
+                  "string",
+                  "Description of the proposal"
+            ]
+          },
+          {
+              "label": "period_count",
+              "value": [
+                  "int64",
+                  28
+              ]
+          }
+      ]
+  ]
 }
 `

--- a/include/assignment.hpp
+++ b/include/assignment.hpp
@@ -9,7 +9,7 @@ namespace hypha
 {
     class dao;
     class TimeShare;
-
+    
     class Assignment : public Document
     {
     public:
@@ -18,6 +18,7 @@ namespace hypha
 
         std::optional<Period> getNextClaimablePeriod ();
         bool isClaimed (Period* period);
+        Period getStartPeriod();
         Member getAssignee();
         eosio::name &getType();
         eosio::time_point getApprovedTime();

--- a/include/assignment.hpp
+++ b/include/assignment.hpp
@@ -19,6 +19,7 @@ namespace hypha
         std::optional<Period> getNextClaimablePeriod ();
         bool isClaimed (Period* period);
         Period getStartPeriod();
+        Period getLastPeriod();
         Member getAssignee();
         eosio::name &getType();
         eosio::time_point getApprovedTime();

--- a/include/common.hpp
+++ b/include/common.hpp
@@ -46,6 +46,7 @@ namespace common
     static constexpr name EDIT = name("edit");
     static constexpr name ORIGINAL = name("original");
     static constexpr name EXTENSION = name("extension");
+    constexpr        name SUSPEND = name("suspend");
 
     static constexpr name ASSIGNED = name("assigned");
     static constexpr name ASSIGNEE_NAME = name("assignee");
@@ -83,6 +84,8 @@ namespace common
     constexpr name INIT_TIME_SHARE = name("initimeshare");
     constexpr name NEXT_TIME_SHARE = name("nextimeshare");
     constexpr name TIME_SHARE_LABEL = name("timeshare");
+    constexpr auto ADJUST_MODIFIER = "modifier";
+    constexpr auto MOD_WITHDRAW = "withdraw";
 
     static constexpr name BALLOT_DEFAULT_OPTION_PASS = name("pass");
     static constexpr name BALLOT_DEFAULT_OPTION_ABSTAIN = name("abstain");

--- a/include/dao.hpp
+++ b/include/dao.hpp
@@ -130,6 +130,9 @@ namespace hypha
 
       ACTION adjustcmtmnt(name issuer, ContentGroups& adjust_info);
 
+      ACTION withdraw(name owner, eosio::checksum256 hash);
+      ACTION suspend(name proposer, eosio::checksum256 hash);
+
       ACTION createroot(const std::string &notes);
       ACTION erasedoc(const eosio::checksum256 &hash);
       ACTION killedge(const uint64_t id);

--- a/include/dao.hpp
+++ b/include/dao.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string_view>
+
 #include <eosio/eosio.hpp>
 #include <eosio/name.hpp>
 #include <eosio/contract.hpp>
@@ -19,6 +21,8 @@ using eosio::name;
 
 namespace hypha
 {
+   class Assignment;
+
    CONTRACT dao : public eosio::contract
    {
    public:
@@ -131,7 +135,7 @@ namespace hypha
       ACTION adjustcmtmnt(name issuer, ContentGroups& adjust_info);
 
       ACTION withdraw(name owner, eosio::checksum256 hash);
-      ACTION suspend(name proposer, eosio::checksum256 hash);
+      ACTION suspend(name proposer, eosio::checksum256 hash, string reason);
 
       ACTION createroot(const std::string &notes);
       ACTION erasedoc(const eosio::checksum256 &hash);
@@ -152,6 +156,11 @@ namespace hypha
       void makePayment(const eosio::checksum256 &fromNode, const eosio::name &recipient,
                        const eosio::asset &quantity, const string &memo,
                        const eosio::name &paymentType);
+
+      void modifyCommitment(Assignment& assignment, 
+                            int64_t commitment,
+                            std::optional<eosio::time_point> fixedStartDate,
+                            std::string_view modifier);
 
    private:
       DocumentGraph m_documentGraph = DocumentGraph(get_self());

--- a/include/period.hpp
+++ b/include/period.hpp
@@ -36,7 +36,8 @@ namespace hypha
 
         Period next();
 
-        Period getNthPeriodAfter(int64_t count);
+        Period getNthPeriodAfter(int64_t count) const;
+        int64_t getPeriodCountTo(Period& other);
 
         static Period asOf(dao *dao, eosio::time_point moment);
         static Period current(dao *dao);

--- a/include/proposals/proposal.hpp
+++ b/include/proposals/proposal.hpp
@@ -47,9 +47,9 @@ namespace hypha
 
         bool didPass(const eosio::checksum256 &tallyHash);
 
-    private:
         string getTitle(ContentWrapper cw) const;
         string getDescription(ContentWrapper cw) const;
+    private:
         bool oldDidPass(const eosio::name &ballotId);
 
     };

--- a/include/proposals/suspend_proposal.hpp
+++ b/include/proposals/suspend_proposal.hpp
@@ -1,0 +1,26 @@
+#pragma once 
+
+#include <eosio/name.hpp>
+
+#include "proposal.hpp"
+
+namespace hypha {
+
+    class SuspendProposal : public Proposal
+    {
+    
+    public:
+        using Proposal::Proposal;
+        Document propose(const name &proposer, ContentGroups &contentGroups);
+        void close(Document &proposal);
+
+    protected:
+
+        void proposeImpl(const name &proposer, ContentWrapper &contentWrapper) override;
+        void postProposeImpl (Document &proposal) override;
+
+        void passImpl(Document &proposal) override;
+        string getBallotContent (ContentWrapper &contentWrapper) override;
+        name getProposalType () override;
+    };
+}

--- a/include/util.hpp
+++ b/include/util.hpp
@@ -9,6 +9,7 @@
 #include <eosio/multi_index.hpp>
 
 #include <document_graph/content_wrapper.hpp>
+#include <document_graph/util.hpp>
 
 namespace hypha
 {
@@ -98,6 +99,9 @@ namespace hypha
       }
       else if constexpr (supports_call_to_string<T>::value) {
         return arg.to_string();
+      }
+      else if constexpr (std::is_same_v<T, eosio::checksum256>) {
+        return readableHash(arg);
       }
       else {
         return arg;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,6 +27,7 @@ add_contract( dao dao
                 proposals/payout_proposal.cpp
                 proposals/attestation_proposal.cpp
                 proposals/edit_proposal.cpp
+                proposals/suspend_proposal.cpp
                 proposals/proposal_factory.cpp
                 ballots/vote.cpp
                 ballots/vote_tally.cpp

--- a/src/assignment.cpp
+++ b/src/assignment.cpp
@@ -157,7 +157,7 @@ namespace hypha
     std::optional<Period> Assignment::getNextClaimablePeriod()
     {
         // Ensure that the claimed period is within the approved period count
-        Period period(m_dao, getContentWrapper().getOrFail(DETAILS, START_PERIOD)->getAs<eosio::checksum256>());
+        Period period = getStartPeriod();
         int64_t periodCount = getContentWrapper().getOrFail(DETAILS, PERIOD_COUNT)->getAs<int64_t>();
         int64_t counter = 0;
 
@@ -207,6 +207,11 @@ namespace hypha
         }
 
         return eosio::asset{0, *symbol};
+    }
+
+    Period Assignment::getStartPeriod()
+    {
+      return Period(m_dao, getContentWrapper().getOrFail(DETAILS, START_PERIOD)->getAs<eosio::checksum256>());
     }
     
     TimeShare Assignment::getInitialTimeShare() 

--- a/src/assignment.cpp
+++ b/src/assignment.cpp
@@ -214,6 +214,13 @@ namespace hypha
       return Period(m_dao, getContentWrapper().getOrFail(DETAILS, START_PERIOD)->getAs<eosio::checksum256>());
     }
     
+    Period Assignment::getLastPeriod()
+    {
+      auto start = getStartPeriod();
+      auto periods = getPeriodCount();
+      return start.getNthPeriodAfter(periods-1);
+    }
+
     TimeShare Assignment::getInitialTimeShare() 
     {
       Edge initialEdge = Edge::get(m_dao->get_self(), getHash(), common::INIT_TIME_SHARE);

--- a/src/dao.cpp
+++ b/src/dao.cpp
@@ -81,7 +81,10 @@ namespace hypha
 
      eosio::name assignee = assignment.getAssignee().getAccount();
 
-     eosio::check(assignee == owner, to_str("Only the member [", assignee.to_string() ,"] can withdraw the assignment [", readableHash(hash), "]"));
+     eosio::check(
+       assignee == owner, 
+       to_str("Only the member [", assignee.to_string() ,"] can withdraw the assignment [", hash, "]")
+     );
 
      eosio::require_auth(owner);
 
@@ -105,33 +108,56 @@ namespace hypha
 
       auto detailsGroup = cw.getGroupOrFail(DETAILS);
 
-      ContentWrapper::insertOrReplace(*detailsGroup, Content { START_PERIOD, periodsToCurrent });
+      ContentWrapper::insertOrReplace(*detailsGroup, Content { PERIOD_COUNT, periodsToCurrent });
 
-      hash = m_documentGraph.updateDocument(assignee, hash, cw.getContentGroups()).getHash();
+      hash = m_documentGraph.updateDocument(assignment.getCreator(), 
+                                            hash, 
+                                            cw.getContentGroups()).getHash();
      } 
      //This has to be the last step, since adjustcmtmnt could change the assignment hash
      //to old assignments
      ContentGroups adjust {
        ContentGroup {
-         Content { "assignment", hash },
-         Content { "new_time_share_x100", 0 },
-         Content { "modifier", common::MOD_WITHDRAW },
+         Content { ASSIGNMENT_STRING, hash },
+         Content { NEW_TIME_SHARE, 0 },
+         Content { common::ADJUST_MODIFIER, common::MOD_WITHDRAW },
        }
      };
 
      adjustcmtmnt(owner, adjust);
    }
 
-   void dao::suspend(name proposer, eosio::checksum256 hash)
+   void dao::suspend(name proposer, eosio::checksum256 hash, string reason)
    {
-     eosio::check(!isPaused(), "Contract is paused for maintenance. Please try again later.");
+     eosio::check(
+       !isPaused(), 
+       "Contract is paused for maintenance. Please try again later."
+     );
 
+     eosio::check(
+       Member::isMember(get_self(), proposer), 
+       to_str("Only members are allowed to propose suspensions")
+     );
 
+     eosio::require_auth(proposer);
+
+     ContentGroups cgs = {
+       ContentGroup {
+          Content { CONTENT_GROUP_LABEL, DETAILS },
+          Content { DESCRIPTION, std::move(reason) },
+          Content { ORIGINAL_DOCUMENT, hash },
+       },
+     };
+
+     propose(proposer, common::SUSPEND, cgs);
    }
 
    void dao::claimnextper(const eosio::checksum256 &assignment_hash)
    {
-      eosio::check(!isPaused(), "Contract is paused for maintenance. Please try again later.");
+      eosio::check(
+        !isPaused(), 
+        "Contract is paused for maintenance. Please try again later."
+      );
 
       Assignment assignment(this, assignment_hash);
 
@@ -667,101 +693,121 @@ namespace hypha
          eosio::check(assignment.getAssignee().getAccount() == issuer,
                       "Only the owner of the assignment can adjust it");
 
-        /**
-        * Checks if the assignment has the original_approved_date item
-        */
-        if (auto [_, approvedItem] = assignment.getContentWrapper().get(SYSTEM, common::APPROVED_DATE); 
-            approvedItem == nullptr) 
-        {
-          auto approvedDate = assignment.getApprovedTime();
-
-          auto system = assignment.getContentWrapper().getGroupOrFail(SYSTEM);
-
-          ContentWrapper::insertOrReplace(*system, Content{common::APPROVED_DATE, approvedDate});
-          
-          auto newDoc = getGraph().updateDocument(assignment.getCreator(), 
-                                                  assignment.getHash(),
-                                                  std::move(assignment.getContentGroups()));
-
-          assignment = Assignment(this, newDoc.getHash());
-        }
-
-        /**
-        * Check if required edges & documents exists for this assignment, otherwise (assignments approved prior dynamic commitments)
-        */
-        if (auto [exists, edge] = Edge::getIfExists(get_self(), assignment.getHash(), common::INIT_TIME_SHARE);
-            !exists)
-        {
-          //We have to create an Inital time share document and all the edges pointing towards it
-          auto contentWrapper = assignment.getContentWrapper();
-
-          //Initial time share for proposal
-          int64_t initTimeShare = contentWrapper.getOrFail(DETAILS, TIME_SHARE)->getAs<int64_t>();
-
-          //Set starting date to approval date.
-          auto approvedDate = assignment.getApprovedTime();
-          TimeShare initTimeShareDoc(get_self(), get_self(), initTimeShare, approvedDate, assignment.getHash());
-
-          Edge::write(get_self(), get_self(), assignment.getHash(), initTimeShareDoc.getHash(), common::INIT_TIME_SHARE);
-          Edge::write(get_self(), get_self(), assignment.getHash(), initTimeShareDoc.getHash(), common::CURRENT_TIME_SHARE);
-          Edge::write(get_self(), get_self(), assignment.getHash(), initTimeShareDoc.getHash(), common::LAST_TIME_SHARE);
-        }
-
-         ContentWrapper assignmentCW = assignment.getContentWrapper();
-
-         Document roleDocument(get_self(), assignmentCW.getOrFail(DETAILS, ROLE_STRING)->getAs<eosio::checksum256>());
-         auto role = roleDocument.getContentWrapper();
-
-         //Check min_time_share_x100 <= new_time_share_x100 <= time_share_x100
-         int64_t originalTimeShare = assignmentCW.getOrFail(DETAILS, TIME_SHARE)->getAs<int64_t>();
-         int64_t minTimeShare = role.getOrFail(DETAILS, MIN_TIME_SHARE)->getAs<int64_t>();
          int64_t newTimeShare = cw.getOrFail(i, NEW_TIME_SHARE).second->getAs<int64_t>();
-         
+
          auto [modifierIdx, modifier] = cw.get(i, common::ADJUST_MODIFIER);
 
-         bool checkNewTimeShareMinMax = true;
-         
-         if (modifier != nullptr) 
-         {
-           string modifierType = modifier->getAs<string>();
-           if (modifierType == common::MOD_WITHDRAW) 
-           {
-             checkNewTimeShareMinMax = false;
-           }
-         }
-         
-         if (checkNewTimeShareMinMax) 
-         {
+         string_view modstr = modifier ? string_view{modifier->getAs<string>()} : string_view{};
 
-          eosio::check(newTimeShare >= minTimeShare,
-                        to_str(NEW_TIME_SHARE, " must be greater than or equal to: ", minTimeShare, " You submitted: ") + std::to_string(newTimeShare));
-          eosio::check(newTimeShare <= originalTimeShare,
-                        NEW_TIME_SHARE + string(" must be less than or equal to original time_share_x100: ") + std::to_string(originalTimeShare) + string(" You submitted: ") + std::to_string(newTimeShare));
-         }
-         //Update lasttimeshare
-         Edge lastTimeShareEdge = Edge::get(get_self(), assignment.getHash(), common::LAST_TIME_SHARE);
+         auto [idx, startDate] = cw.get(i, TIME_SHARE_START_DATE);
 
-         time_point startDate = eosio::current_time_point();
-
-         if (auto [idx, startDateContent] = cw.get(i, TIME_SHARE_START_DATE);
-             startDateContent)
-         {
-            TimeShare lastTimeShare(get_self(), lastTimeShareEdge.getToNode());
-            time_point lastStartDate = lastTimeShare.getContentWrapper()
-                                           .getOrFail(DETAILS, TIME_SHARE_START_DATE)
-                                           ->getAs<time_point>();
-            startDate = startDateContent->getAs<time_point>();
-            eosio::check(lastStartDate.sec_since_epoch() < startDate.sec_since_epoch(),
-                         "New time share start date must be greater than the previous time share");
-         }
-
-         TimeShare newTimeShareDoc(get_self(), issuer, newTimeShare, startDate, assignment.getHash());
-
-         Edge::write(get_self(), get_self(), lastTimeShareEdge.getToNode(), newTimeShareDoc.getHash(), common::NEXT_TIME_SHARE);
-
-         lastTimeShareEdge.erase();
-
-         Edge::write(get_self(), get_self(), assignment.getHash(), newTimeShareDoc.getHash(), common::LAST_TIME_SHARE);
+         auto fixedStartDate = startDate ? std::optional<time_point>{startDate->getAs<time_point>()} : std::nullopt;
+        
+         modifyCommitment(assignment, 
+                          newTimeShare, 
+                          fixedStartDate,  
+                          modstr);
       }
+   }
+
+   void dao::modifyCommitment(Assignment& assignment, int64_t commitment, std::optional<eosio::time_point> fixedStartDate, std::string_view modifier)
+   {
+      /**
+      * Checks if the assignment has the original_approved_date item
+      */
+      if (auto [_, approvedItem] = assignment.getContentWrapper().get(SYSTEM, common::APPROVED_DATE); 
+          approvedItem == nullptr) 
+      {
+        auto approvedDate = assignment.getApprovedTime();
+
+        auto system = assignment.getContentWrapper().getGroupOrFail(SYSTEM);
+
+        ContentWrapper::insertOrReplace(*system, Content{common::APPROVED_DATE, approvedDate});
+        
+        auto newDoc = getGraph().updateDocument(assignment.getCreator(), 
+                                                     assignment.getHash(),
+                                                     std::move(assignment.getContentGroups()));
+
+        assignment = Assignment(this, newDoc.getHash());
+      }
+
+      /**
+      * Check if required edges & documents exists for this assignment, otherwise (assignments approved prior dynamic commitments)
+      */
+      if (auto [exists, edge] = Edge::getIfExists(get_self(), assignment.getHash(), common::INIT_TIME_SHARE);
+          !exists)
+      {
+        //We have to create an Inital time share document and all the edges pointing towards it
+        auto contentWrapper = assignment.getContentWrapper();
+
+        //Initial time share for proposal
+        int64_t initTimeShare = contentWrapper.getOrFail(DETAILS, TIME_SHARE)->getAs<int64_t>();
+
+        //Set starting date to approval date.
+        auto approvedDate = assignment.getApprovedTime();
+        TimeShare initTimeShareDoc(get_self(), get_self(), initTimeShare, approvedDate, assignment.getHash());
+
+        Edge::write(get_self(), get_self(), assignment.getHash(), initTimeShareDoc.getHash(), common::INIT_TIME_SHARE);
+        Edge::write(get_self(), get_self(), assignment.getHash(), initTimeShareDoc.getHash(), common::CURRENT_TIME_SHARE);
+        Edge::write(get_self(), get_self(), assignment.getHash(), initTimeShareDoc.getHash(), common::LAST_TIME_SHARE);
+      }
+
+      ContentWrapper assignmentCW = assignment.getContentWrapper();
+
+      Document roleDocument(get_self(), assignmentCW.getOrFail(DETAILS, ROLE_STRING)->getAs<eosio::checksum256>());
+      auto role = roleDocument.getContentWrapper();
+
+      //Check min_time_share_x100 <= new_time_share_x100 <= time_share_x100
+      int64_t originalTimeShare = assignmentCW.getOrFail(DETAILS, TIME_SHARE)->getAs<int64_t>();
+      int64_t minTimeShare = role.getOrFail(DETAILS, MIN_TIME_SHARE)->getAs<int64_t>();
+              
+      bool checkNewTimeShareMin = true;
+      
+      if (modifier == common::MOD_WITHDRAW) 
+      {
+        checkNewTimeShareMin = false;
+      }
+      
+      if (checkNewTimeShareMin) 
+      {
+        eosio::check(
+          commitment >= minTimeShare,
+          to_str(NEW_TIME_SHARE, " must be greater than or equal to: ", minTimeShare, " You submitted: ", commitment)
+        );
+      }
+
+      eosio::check(
+        commitment <= originalTimeShare,
+        to_str(NEW_TIME_SHARE, " must be less than or equal to original (approved) time_share_x100: ", originalTimeShare, " You submitted: ", commitment)
+      );
+
+      //Update lasttimeshare
+      Edge lastTimeShareEdge = Edge::get(get_self(), assignment.getHash(), common::LAST_TIME_SHARE);
+
+      time_point startDate = eosio::current_time_point();
+
+      if (fixedStartDate)
+      {
+        TimeShare lastTimeShare(get_self(), lastTimeShareEdge.getToNode());
+        time_point lastStartDate = lastTimeShare.getContentWrapper()
+                                                .getOrFail(DETAILS, TIME_SHARE_START_DATE)
+                                                ->getAs<time_point>();
+
+        startDate = *fixedStartDate;
+        eosio::check(lastStartDate.sec_since_epoch() < startDate.sec_since_epoch(),
+                      "New time share start date must be greater than the previous time share start date");
+      }
+
+      TimeShare newTimeShareDoc(get_self(), 
+                                assignment.getAssignee().getAccount(), 
+                                commitment, 
+                                startDate, 
+                                assignment.getHash());
+
+      Edge::write(get_self(), get_self(), lastTimeShareEdge.getToNode(), newTimeShareDoc.getHash(), common::NEXT_TIME_SHARE);
+
+      lastTimeShareEdge.erase();
+
+      Edge::write(get_self(), get_self(), assignment.getHash(), newTimeShareDoc.getHash(), common::LAST_TIME_SHARE);
    }
 } // namespace hypha

--- a/src/period.cpp
+++ b/src/period.cpp
@@ -123,7 +123,7 @@ namespace hypha
         return Period(m_dao, period.getToNode());
     }
 
-    Period Period::getNthPeriodAfter(int64_t count)
+    Period Period::getNthPeriodAfter(int64_t count) const
     {
         Period next = *this;
 
@@ -141,5 +141,29 @@ namespace hypha
         }
 
         return next;
+    }
+
+    int64_t Period::getPeriodCountTo(Period& other)
+    {
+      auto otherStartSec = other.getStartTime().sec_since_epoch();
+      auto currentStartSec = getStartTime().sec_since_epoch();
+
+      bool isAfterOther = currentStartSec > otherStartSec;
+
+      auto startPeriod = isAfterOther ? other : *this;
+      auto& endPeriod = isAfterOther ? *this : other;
+
+      int64_t count = 0;
+
+      while (startPeriod.getHash() != endPeriod.getHash()) {
+        ++count;
+        startPeriod = startPeriod.next();
+      }
+
+      if (isAfterOther) {
+        count *= -1;
+      }
+
+      return count;
     }
 } // namespace hypha

--- a/src/period.cpp
+++ b/src/period.cpp
@@ -125,6 +125,11 @@ namespace hypha
 
     Period Period::getNthPeriodAfter(int64_t count) const
     {
+        eosio::check(
+          count >= 0, 
+          "Period::getNthPeriodAfter: Count has to be greater or equal to 0"
+        );
+
         Period next = *this;
 
         while (count-- > 0)

--- a/src/proposals/edit_proposal.cpp
+++ b/src/proposals/edit_proposal.cpp
@@ -146,18 +146,7 @@ namespace hypha
 
     std::string EditProposal::getBallotContent (ContentWrapper &contentWrapper)
     {
-        auto [titleIdx, title] = contentWrapper.get(DETAILS, TITLE);
-
-        auto [ballotTitleIdx, ballotTitle] = contentWrapper.get(DETAILS, common::BALLOT_TITLE);
-
-        eosio::check(
-          title != nullptr || ballotTitle != nullptr,
-          to_str("Proposal [details] group must contain at least one of the following items [", 
-                  TITLE, ", ", common::BALLOT_TITLE, "]")
-        );
-
-        return title != nullptr ? title->getAs<std::string>() : 
-                                  ballotTitle->getAs<std::string>();
+        return getTitle();
     }
     
     name EditProposal::getProposalType () 

--- a/src/proposals/edit_proposal.cpp
+++ b/src/proposals/edit_proposal.cpp
@@ -50,23 +50,17 @@ namespace hypha
                   std::to_string(currentPeriodCount) + "; proposed: " + std::to_string(newPeriodCount)
                 );    
             }
-            
-            //TODO: Check if we have at least 1+ period remaining, 
-            //otherwise we deny the edit/extension                         
-            auto startPeriodHash = assignment.getContentWrapper()
-                                             .getOrFail(DETAILS, START_PERIOD)->getAs<eosio::checksum256>();
-
-            auto startPeriod = Period(&m_dao, startPeriodHash);
-
+                           
             auto currentTimeSecs = eosio::current_time_point().sec_since_epoch();
 
-            auto lastPeriodStartSecs = startPeriod.getNthPeriodAfter(currentPeriodCount-1)
+            auto lastPeriodStartSecs = assignment.getLastPeriod()
                                                   .getStartTime()
                                                   .sec_since_epoch();
 
             eosio::check(
               lastPeriodStartSecs > currentTimeSecs, 
-              "There has to be at least 1 remaining period before editing an assignment"
+              "There has to be at least 1 remaining period before editing/extending an assignment"
+              ", create a new one instead"
             );
             
             original = std::move(*static_cast<Document*>(&assignment));
@@ -76,7 +70,6 @@ namespace hypha
             original = Document(m_dao.get_self(), originalDocHash);
         }
 
-        //TODO: This edge has to be cleaned up when the proposal fails
         // connect the edit proposal to the original
         Edge::write (m_dao.get_self(), m_dao.get_self(), proposal.getHash(), original.getHash(), common::ORIGINAL);
     }

--- a/src/proposals/proposal_factory.cpp
+++ b/src/proposals/proposal_factory.cpp
@@ -7,7 +7,9 @@
 #include <proposals/assignment_proposal.hpp>
 #include <proposals/attestation_proposal.hpp>
 #include <proposals/edit_proposal.hpp>
+#include <proposals/suspend_proposal.hpp>
 #include <proposals/ass_extend_proposal.hpp>
+
 #include <common.hpp>
 
 namespace hypha
@@ -33,6 +35,9 @@ namespace hypha
 
         case common::ATTESTATION.value:
             return new AttestationProposal(dao);
+
+        case common::SUSPEND.value: 
+            return new SuspendProposal(dao);
 
         case common::EDIT.value:
             return new EditProposal(dao);

--- a/src/proposals/suspend_proposal.cpp
+++ b/src/proposals/suspend_proposal.cpp
@@ -6,19 +6,19 @@
 
 #include <common.hpp>
 #include <util.hpp>
-#include <proposals/edit_proposal.hpp>
+#include <proposals/suspend_proposal.hpp>
 #include <assignment.hpp>
 #include <period.hpp>
 
 namespace hypha
 {
 
-    void EditProposal::proposeImpl(const name &proposer, ContentWrapper &contentWrapper)
+    void SuspendProposal::proposeImpl(const name &proposer, ContentWrapper &contentWrapper)
     { 
       
     }
 
-    void EditProposal::postProposeImpl (Document &proposal) 
+    void SuspendProposal::postProposeImpl (Document &proposal) 
     {
         ContentWrapper proposalContent = proposal.getContentWrapper();
 
@@ -81,7 +81,7 @@ namespace hypha
         Edge::write (m_dao.get_self(), m_dao.get_self(), proposal.getHash(), original.getHash(), common::ORIGINAL);
     }
 
-    void EditProposal::passImpl(Document &proposal)
+    void SuspendProposal::passImpl(Document &proposal)
     {
         // merge the original with the edits and save
         ContentWrapper proposalContent = proposal.getContentWrapper();
@@ -144,14 +144,14 @@ namespace hypha
         proposalContent.getContentGroups() = std::move(originalContents);
     }
 
-    std::string EditProposal::getBallotContent (ContentWrapper &contentWrapper)
+    std::string SuspendProposal::getBallotContent (ContentWrapper &contentWrapper)
     {
         return getTitle(contentWrapper);
     }
     
-    name EditProposal::getProposalType () 
+    name SuspendProposal::getProposalType () 
     {
-        return common::EDIT;
+        return common::SUSPEND;
     }
 
 } // namespace hypha


### PR DESCRIPTION
+ Added Withdraw action
+ Added Suspend action 
+ Added Suspend proposal
+ Added tests for both Withdraw and Suspend actions

Overview:
Any user can withdraw only owned assignments 
Any user can propose a suspension on others assignments

On both scenarios (if proposal passes) the assignment changes the period count to the current period and adds a time commitment of 0. This way the user is still able to claim the periods/days prior to withdraw.