### PR TITLE
Suspend Role

### DIFF
--- a/dao-go/assignments_test.go
+++ b/dao-go/assignments_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-  eostest "github.com/digital-scarcity/eos-go-test"
+	eostest "github.com/digital-scarcity/eos-go-test"
 	"github.com/eoscanada/eos-go"
 	"github.com/hypha-dao/document-graph/docgraph"
 	"gotest.tools/assert"
@@ -156,7 +156,6 @@ func ValidateLastReceipt(targetHUSD, targetHYPHA, targetHVOICE, targetSEEDS int6
 }
 
 func TestAdjustCommitment(t *testing.T) {
-  t.Skip("Skipping failing test")
   teardownTestCase := setupTestCase(t)
   defer teardownTestCase(t)
 
@@ -293,7 +292,7 @@ func TestAdjustCommitment(t *testing.T) {
 
       //Claim first period
       t.Log("Waiting for a period to lapse...")
-      eostest.Pause(env.PeriodPause, "", "Waiting...")
+      eostest.Pause(env.PeriodPause*2, "", "Waiting...")
 
       //This should get partial payment since the approved time should be > than
       //the start time of the period

--- a/include/common.hpp
+++ b/include/common.hpp
@@ -47,12 +47,20 @@ namespace common
     static constexpr name ORIGINAL = name("original");
     static constexpr name EXTENSION = name("extension");
     constexpr        name SUSPEND = name("suspend");
+    constexpr        name SUSPENDED = name("suspended");
 
     static constexpr name ASSIGNED = name("assigned");
     static constexpr name ASSIGNEE_NAME = name("assignee");
     constexpr        auto APPROVED_DATE = "original_approved_date";
     constexpr        auto BALLOT_TITLE = "ballot_title";
     constexpr        auto BALLOT_DESCRIPTION = "ballot_description";
+    constexpr        auto STATE = "state";
+    constexpr        auto STATE_PROPOSED = "proposed";
+    constexpr        auto STATE_APPROVED = "approved";
+    constexpr        auto STATE_REJECTED = "rejected";
+    constexpr        auto STATE_SUSPENDED = "suspended";
+    constexpr        auto STATE_EXPIRED = "expired";
+    constexpr        auto STATE_WITHDRAWED = "withdrawed";
     static constexpr name PERIOD = name("period");
     static constexpr name START = name ("start");
     static constexpr name NEXT = name ("next");

--- a/include/dao.hpp
+++ b/include/dao.hpp
@@ -143,6 +143,7 @@ namespace hypha
       ACTION newedge(eosio::name & creator, const checksum256 &from_node, const checksum256 &to_node, const name &edge_name);
       ACTION updatedoc(const eosio::checksum256 hash, const name &updater, const string &group, const string &key, const Content::FlexValue &value);
       ACTION fix (const eosio::checksum256 &hash);
+      ACTION addstate (const std::vector<eosio::checksum256>& hashes);
       // ACTION nbadge (const name& owner, const ContentGroups& contentGroups);
       // ACTION nbadass(const name& owner, const ContentGroups& contentGroups);
       // ACTION nbadprop (const name& owner, const ContentGroups& contentGroups);

--- a/include/period.hpp
+++ b/include/period.hpp
@@ -38,8 +38,10 @@ namespace hypha
 
         Period getNthPeriodAfter(int64_t count) const;
         int64_t getPeriodCountTo(Period& other);
+        Period getPeriodUntil(eosio::time_point moment);
 
         static Period asOf(dao *dao, eosio::time_point moment);
+        
         static Period current(dao *dao);
         bool isEnd();
 

--- a/include/proposals/proposal.hpp
+++ b/include/proposals/proposal.hpp
@@ -49,6 +49,8 @@ namespace hypha
 
         string getTitle(ContentWrapper cw) const;
         string getDescription(ContentWrapper cw) const;
+
+        std::pair<bool, checksum256> hasOpenProposal(name proposalType, checksum256 docHash);
     private:
         bool oldDidPass(const eosio::name &ballotId);
 

--- a/src/period.cpp
+++ b/src/period.cpp
@@ -131,7 +131,7 @@ namespace hypha
         TRACE_FUNCTION()
         EOS_CHECK(
           count >= 0, 
-          "Period::getNthPeriodAfter: Count has to be greater or equal to 0"
+          "Count has to be greater or equal to 0"
         );
 
         Period next = *this;
@@ -175,5 +175,28 @@ namespace hypha
       }
 
       return count;
+    }
+
+    Period Period::getPeriodUntil(eosio::time_point moment)
+    {
+      TRACE_FUNCTION()
+
+      Period next = *this;
+
+      EOS_CHECK(
+        moment >= next.getStartTime(),
+        to_str("Moment must happen after period start date, [moment secs]:", 
+                moment.sec_since_epoch(), " [period]:", getHash())
+      );
+
+      while (moment > next.getEndTime()) {
+        auto [hasNext, edge] = Edge::getIfExists(m_dao->get_self(), next.getHash(), common::NEXT);
+
+        EOS_CHECK(hasNext, "End of calendar has been reached. Contact administrator to add more time periods.");
+
+        next = Period(m_dao, edge.getToNode());
+      }
+
+      return next;
     }
 } // namespace hypha

--- a/src/proposals/assignment_proposal.cpp
+++ b/src/proposals/assignment_proposal.cpp
@@ -23,6 +23,13 @@ namespace hypha
         Document roleDocument(m_dao.get_self(), assignment.getOrFail(DETAILS, ROLE_STRING)->getAs<eosio::checksum256>());
         auto role = roleDocument.getContentWrapper();
 
+        auto root = getRoot(m_dao.get_self());
+        
+        EOS_CHECK(
+          !Edge::exists(m_dao.get_self(), root, roleDocument.getHash(), common::SUSPENDED),
+          "Cannot create assignment proposal of suspened role"
+        )
+
         // role in the proposal must be of type: role
         EOS_CHECK(role.getOrFail(SYSTEM, TYPE)->getAs<eosio::name>() == common::ROLE_NAME,
                      "role document hash provided in assignment proposal is not of type: role");
@@ -121,18 +128,25 @@ namespace hypha
         TRACE_FUNCTION()
         ContentWrapper contentWrapper = proposal.getContentWrapper();
         eosio::checksum256 assignee = Member::calcHash(contentWrapper.getOrFail(DETAILS, ASSIGNEE)->getAs<eosio::name>());
-        Document role(m_dao.get_self(), contentWrapper.getOrFail(DETAILS, ROLE_STRING)->getAs<eosio::checksum256>());
+
+        auto assignmentToRoleEdge = m_dao.getGraph().getEdgesFrom(proposal.getHash(), common::ROLE_NAME);
+      
+        EOS_CHECK(
+          !assignmentToRoleEdge.empty(),
+          to_str("Missing 'role' edge from assignment: ", proposal.getHash())
+        )
+
+        Document role(m_dao.get_self(), assignmentToRoleEdge.at(0).getToNode());
 
         // update graph edges:
         //  member          ---- assigned           ---->   role_assignment
         //  role_assignment ---- assignee           ---->   member
-        //  role_assignment ---- role               ---->   role
+        //  role_assignment ---- role               ---->   role                This one already exists since postProposeImpl
         //  role            ---- role_assignment    ---->   role_assignment
         Edge::write(m_dao.get_self(), m_dao.get_self(), assignee, proposal.getHash(), common::ASSIGNED);
         Edge::write(m_dao.get_self(), m_dao.get_self(), proposal.getHash(), assignee, common::ASSIGNEE_NAME);
         Edge::write(m_dao.get_self(), m_dao.get_self(), role.getHash(), proposal.getHash(), common::ASSIGNMENT);
-        Edge::write(m_dao.get_self(), m_dao.get_self(), proposal.getHash(), role.getHash(), common::ROLE_NAME);
-
+        
         //Start period edge
         // assignment ---- start ----> period
         eosio::checksum256 startPeriod = contentWrapper.getOrFail(DETAILS, START_PERIOD)->getAs<eosio::checksum256>();

--- a/src/proposals/suspend_proposal.cpp
+++ b/src/proposals/suspend_proposal.cpp
@@ -76,9 +76,7 @@ namespace hypha
         );
        } break;
       case common::ROLE_NAME.value:
-
-        
-
+        //We don't have to do anything special for roles
         break;
       default:
         EOS_CHECK(
@@ -166,7 +164,7 @@ namespace hypha
         m_dao.modifyCommitment(assignment, 0, std::nullopt, common::MOD_WITHDRAW);
       } break;
       case common::ROLE_NAME.value: {
-        
+        //We don't have to do anything special for roles
       }  break;
       default: {
         EOS_CHECK(

--- a/src/proposals/suspend_proposal.cpp
+++ b/src/proposals/suspend_proposal.cpp
@@ -18,15 +18,43 @@ namespace hypha
 
     void SuspendProposal::proposeImpl(const name &proposer, ContentWrapper &contentWrapper)
     { 
-      //TODO: Setup ballot_title according to document type [Assignment, Badge, etc.]
       TRACE_FUNCTION()
 
       // original_document is a required hash
       auto originalDocHash = contentWrapper.getOrFail(DETAILS, ORIGINAL_DOCUMENT)->getAs<eosio::checksum256>();
 
+      auto root = getRoot(m_dao.get_self());
+
+      //Verify if this is a passed proposal
+      EOS_CHECK(
+        Edge::exists(m_dao.get_self(), root, originalDocHash, common::PASSED_PROPS),
+        "Only passed proposals can be suspended"
+      )
+      
       Document originalDoc(m_dao.get_self(), originalDocHash);
 
+      if (auto [hasOpenSuspendProp, proposalHash] = hasOpenProposal(common::SUSPEND, originalDocHash);
+          hasOpenSuspendProp) {
+        EOS_CHECK(
+          false,
+          to_str("There is an open suspension proposal already:", proposalHash)  
+        )
+      }
+
       ContentWrapper ocw = originalDoc.getContentWrapper();
+
+      //TODO-J: Add state item to all active Roles/Assignments
+      //Check assignments from 2 months ago with dgraph and then send them to a fix action (should verify if they are still active or not)
+      //Check all roles that are not suspened (?)
+      auto state = ocw.getOrFail(DETAILS, common::STATE)->getAs<string>();
+
+      EOS_CHECK(
+        state != common::STATE_WITHDRAWED && 
+        state != common::STATE_SUSPENDED &&
+        state != common::STATE_EXPIRED &&
+        state != common::STATE_REJECTED,
+        to_str("Cannot open suspend proposals on ", state, " documents")
+      )
 
       auto type = ocw.getOrFail(SYSTEM, TYPE)->getAs<name>();
       
@@ -47,6 +75,11 @@ namespace hypha
           "Assignment is already expired"
         );
        } break;
+      case common::ROLE_NAME.value:
+
+        
+
+        break;
       default:
         EOS_CHECK(
           false,
@@ -59,7 +92,7 @@ namespace hypha
       auto title = ocw.getOrFail(DETAILS, TITLE)->getAs<string>();
 
       ContentWrapper::insertOrReplace(*contentWrapper.getGroupOrFail(DETAILS), 
-                                      Content { TITLE, to_str("Suspention of ", type, ":", title ) });
+                                      Content { TITLE, to_str("Suspension of ", type, ": ", title ) });
     }
 
     void SuspendProposal::postProposeImpl (Document &proposal) 
@@ -82,9 +115,19 @@ namespace hypha
         "Missing edge from suspension proposal: " + readableHash(proposal.getHash()) + " to document"
       );
 
+      auto root = getRoot(m_dao.get_self());
+
       Document originalDoc(m_dao.get_self(), edges[0].getToNode());
 
       ContentWrapper ocw = originalDoc.getContentWrapper();
+
+      auto detailsGroup = ocw.getGroupOrFail(DETAILS);
+
+      ContentWrapper::insertOrReplace(*detailsGroup, Content { common::STATE, common::STATE_SUSPENDED });
+
+      originalDoc = m_dao.getGraph().updateDocument(originalDoc.getCreator(), 
+                                                    originalDoc.getHash(), 
+                                                    ocw.getContentGroups());
 
       auto type = ocw.getOrFail(SYSTEM, TYPE)->getAs<name>();
       
@@ -98,10 +141,12 @@ namespace hypha
 
         auto originalPeriods = assignment.getPeriodCount();
 
+        auto startPeriod = assignment.getStartPeriod();
+
         //Calculate the number of periods since start period to the current period
-        auto currentPeriod = Period::current(&m_dao);
+        auto currentPeriod = startPeriod.getPeriodUntil(eosio::current_time_point());
         
-        auto periodsToCurrent = assignment.getStartPeriod().getPeriodCountTo(currentPeriod);
+        auto periodsToCurrent = startPeriod.getPeriodCountTo(currentPeriod);
 
         periodsToCurrent = std::min(periodsToCurrent + 1, originalPeriods);
 
@@ -111,15 +156,18 @@ namespace hypha
 
           ContentWrapper::insertOrReplace(*detailsGroup, Content { PERIOD_COUNT, periodsToCurrent });
 
-          auto newHash = m_dao.getGraph().updateDocument(assignment.getCreator(), 
+          originalDoc = m_dao.getGraph().updateDocument(assignment.getCreator(), 
                                                          assignment.getHash(), 
-                                                         cw.getContentGroups()).getHash();
+                                                         cw.getContentGroups());
 
-          assignment = Assignment(&m_dao, newHash);
+          assignment = Assignment(&m_dao, originalDoc.getHash());
         }
 
         m_dao.modifyCommitment(assignment, 0, std::nullopt, common::MOD_WITHDRAW);
       } break;
+      case common::ROLE_NAME.value: {
+        
+      }  break;
       default: {
         EOS_CHECK(
           false,
@@ -128,6 +176,9 @@ namespace hypha
         );
       } break;
       }
+
+      //root --> suspended --> proposal
+      Edge(m_dao.get_self(), m_dao.get_self(), root, originalDoc.getHash(), common::SUSPENDED);
     }
 
     std::string SuspendProposal::getBallotContent (ContentWrapper &contentWrapper)
@@ -140,5 +191,4 @@ namespace hypha
     {
         return common::SUSPEND;
     }
-
 } // namespace hypha

--- a/tests/assignments.test.ts
+++ b/tests/assignments.test.ts
@@ -1,0 +1,39 @@
+import { setupEnvironment } from './setup';
+import { Document } from './types/Document';
+import { last } from './utils/Arrays';
+import { getContent, getContentGroupByLabel, getDetailsGroup, getDocumentsByType } from './utils/Dao';
+import { nextDay, setDate } from './utils/Date';
+import { getDaoExpect } from './utils/Expect';
+import { UnderwaterBasketweaver } from './sample-data/RoleSamples';
+import { DaoBlockchain } from './dao/DaoBlockchain';
+import { getAssignmentProposal } from './sample-data/AssignmentSamples';
+import { proposeAndPass } from './utils/Proposal';
+
+describe('Assignments', () => {
+    
+    it('Create assignment', async () => {
+
+        //TODO: Generate initial periods
+
+        const environment = await setupEnvironment();
+
+        const now = new Date();
+
+        environment.setCurrentTime(now);
+
+        let role = await proposeAndPass(UnderwaterBasketweaver, 'role', now, environment);
+
+        const assigne = environment.members[0];
+
+        const assignProposal = getAssignmentProposal({ role: role.hash, assignee: assigne.account.accountName });
+
+        // let assignment = await proposeAndPass(assignProposal, 'assignment', now, environment);
+
+        // console.log("Passed assignment:", assignment);
+
+        // let assignmetDetails = getContentGroupByLabel(assignment, 'details');
+        
+        // await expect(getContent(assignmetDetails, 'state').value[1])
+        //       .toBe('approved');
+    });
+});

--- a/tests/proposal.test.ts
+++ b/tests/proposal.test.ts
@@ -38,7 +38,7 @@ describe('Proposal', () => {
             content_groups: getSampleRole().content_groups
         });
 
-        const proposal = last(getDocumentsByType(
+        let proposal = last(getDocumentsByType(
             environment.getDaoDocuments(),
             'role'
         ));
@@ -55,6 +55,11 @@ describe('Proposal', () => {
         await environment.dao.contract.closedocprop({
             proposal_hash: proposal.hash
         }, environment.members[0].getPermissions());
+
+        proposal = last(getDocumentsByType(
+          environment.getDaoDocuments(),
+          'role'
+        ));
 
         daoExpect.toHaveEdge(environment.getRoot(), proposal, 'failedprops');
     });

--- a/tests/roles.test.ts
+++ b/tests/roles.test.ts
@@ -36,8 +36,8 @@ describe('Roles', () => {
 
         let proposalDetails = getDetailsGroup(proposal);
 
-        await expect(getContent(proposalDetails, "state").value[1])
-              .toBe('proposed');
+        expect(getContent(proposalDetails, "state").value[1])
+        .toBe('proposed');
         
         let date = nextDay(environment, new Date());
 
@@ -55,8 +55,8 @@ describe('Roles', () => {
 
         proposalDetails = getDetailsGroup(proposal);
 
-        await expect(getContent(proposalDetails, "state").value[1])
-              .toBe('rejected');
+        expect(getContent(proposalDetails, "state").value[1])
+        .toBe('rejected');
 
         //Propose the role again
        
@@ -78,7 +78,6 @@ describe('Roles', () => {
               .toBe('proposed');
 
         for (let i = 0; i < environment.members.length; ++i) {
-          console.log("Voting to pass:", i);
           await environment.dao.contract.vote({
             voter: environment.members[i].account.accountName,
             proposal_hash: proposal.hash,

--- a/tests/roles.test.ts
+++ b/tests/roles.test.ts
@@ -1,0 +1,112 @@
+import { setupEnvironment } from './setup';
+import { Document } from './types/Document';
+import { last } from './utils/Arrays';
+import { getContent, getContentGroupByLabel, getDetailsGroup, getDocumentsByType } from './utils/Dao';
+import { nextDay, setDate } from './utils/Date';
+import { getDaoExpect } from './utils/Expect';
+import { UnderwaterBasketweaver } from './sample-data/RoleSamples';
+
+describe('Roles', () => {
+
+    const testRole = UnderwaterBasketweaver;
+    let roleDocument: Document;
+    
+    it('Create role', async () => {
+
+        const environment = await setupEnvironment();
+        // Time doesn't move in the test unless we set the current time.
+        const now = new Date();
+
+        // We have to set the initial time if we care about any timing
+        environment.setCurrentTime(now);
+
+        // Proposing
+        await environment.dao.contract.propose({
+            proposer: environment.members[0].account.accountName,
+            proposal_type: 'role',
+            ...testRole
+        });
+        
+        let proposal = last(getDocumentsByType(
+            environment.getDaoDocuments(),
+            'role'
+        ));
+
+        getDaoExpect(environment).toHaveEdge(environment.getRoot(), proposal, 'proposal');
+
+        let proposalDetails = getDetailsGroup(proposal);
+
+        await expect(getContent(proposalDetails, "state").value[1])
+              .toBe('proposed');
+        
+        let date = nextDay(environment, new Date());
+
+        // closes proposal
+        await environment.dao.contract.closedocprop({
+          proposal_hash: proposal.hash
+        }, environment.members[0].getPermissions())
+      
+        proposal = last(getDocumentsByType(
+          environment.getDaoDocuments(),
+          'role'
+        ));
+
+        getDaoExpect(environment).toHaveEdge(environment.getRoot(), proposal, 'failedprops');
+
+        proposalDetails = getDetailsGroup(proposal);
+
+        await expect(getContent(proposalDetails, "state").value[1])
+              .toBe('rejected');
+
+        //Propose the role again
+       
+        // Proposing
+        await environment.dao.contract.propose({
+            proposer: environment.members[0].account.accountName,
+            proposal_type: 'role',
+            ...testRole
+        });
+        
+        proposal = last(getDocumentsByType(
+            environment.getDaoDocuments(),
+            'role'
+        ));
+
+        proposalDetails = getDetailsGroup(proposal);
+
+        await expect(getContent(proposalDetails, "state").value[1])
+              .toBe('proposed');
+
+        for (let i = 0; i < environment.members.length; ++i) {
+          console.log("Voting to pass:", i);
+          await environment.dao.contract.vote({
+            voter: environment.members[i].account.accountName,
+            proposal_hash: proposal.hash,
+            vote: 'pass',
+            notes: 'votes pass'
+          });
+        }
+
+        const expiration = getContent(getContentGroupByLabel(proposal, "ballot"), "expiration");
+        
+        date = setDate(environment, new Date(expiration.value[1]), 15);
+
+        // closes proposal
+        await environment.dao.contract.closedocprop({
+          proposal_hash: proposal.hash
+        }, environment.members[0].getPermissions());
+      
+        proposal = last(getDocumentsByType(
+          environment.getDaoDocuments(),
+          'role'
+        ));
+
+        proposalDetails = getDetailsGroup(proposal);
+
+        getDaoExpect(environment).toHaveEdge(environment.getRoot(), proposal, 'passedprops');
+        getDaoExpect(environment).toHaveEdge(environment.getRoot(), proposal, 'role');
+
+        await expect(getContent(proposalDetails, "state").value[1])
+              .toBe('approved');
+    });
+});

--- a/tests/sample-data/AssignmentSamples.ts
+++ b/tests/sample-data/AssignmentSamples.ts
@@ -1,0 +1,46 @@
+import { DocumentBuilder } from "../utils/DocumentBuilder";
+import { Document } from "../types/Document"
+
+export interface AssignmentProposal {
+  title?: string
+  description?: string
+  annual_usd_salary?: string
+  start_period?: string | undefined
+  period_count?: number
+  time_share?: number
+  deferred_perc?: number
+  role: string
+  assignee: string
+}
+
+const getAssignmentProposal = ({
+  title = 'Underwater Basketweaver - Assignment', 
+  description = 'Weave baskets at the bottom of the sea',
+  start_period,
+  period_count = 12,
+  time_share = 100,
+  deferred_perc = 50,
+  role,
+  assignee
+}: AssignmentProposal): Document => DocumentBuilder
+.builder()
+.contentGroup(builder => {
+  builder
+  .groupLabel('details')
+  .string('title', title)
+  .string('description', description)
+  .name('assignee', assignee)
+  .checksum256('role', role)
+  .int64('period_count', period_count)
+  .int64('time_share_x100', time_share)
+  .int64('deferred_perc_x100', deferred_perc);
+
+  if (start_period) {
+    builder.checksum256('start_period', start_period);
+  }
+})
+.build();
+
+export {
+  getAssignmentProposal,
+}

--- a/tests/sample-data/RoleSamples.ts
+++ b/tests/sample-data/RoleSamples.ts
@@ -1,0 +1,43 @@
+import { DocumentBuilder } from "../utils/DocumentBuilder";
+import { Document } from "../types/Document"
+
+export interface RoleProposal {
+  title?: string
+  description?: string
+  annual_usd_salary?: string
+  start_period?: string | undefined
+  fulltime_capacity?: number
+  min_time_share?: number
+  min_deferred?: number
+}
+
+const getRoleProposal = ({
+  title = 'Underwater Basketweaver', 
+  description = 'Weave baskets at the bottom of the sea',
+  annual_usd_salary = '150000.00 USD',
+  fulltime_capacity = 100,
+  min_time_share = 30,
+  min_deferred = 30
+}: RoleProposal): Document => DocumentBuilder
+.builder()
+.contentGroup(builder => {
+  builder
+  .groupLabel('details')
+  .string('title', title)
+  .string('description', description)
+  .asset('annual_usd_salary', annual_usd_salary)
+  .int64('fulltime_capacity_x100', fulltime_capacity)
+  .int64('min_time_share_x100', min_time_share)
+  .int64('min_deferred_x100', min_deferred);
+})
+.build();
+
+const UnderwaterBasketweaver = getRoleProposal({
+  min_time_share: 50,
+  min_deferred: 50, 
+}); 
+
+export {
+  getRoleProposal,
+  UnderwaterBasketweaver
+}

--- a/tests/types/Document.ts
+++ b/tests/types/Document.ts
@@ -17,7 +17,8 @@ export enum ContentType {
     ASSET = 'asset',
     NAME = 'name',
     INT64 = 'int64',
-    TIME_POINT = 'time_point'
+    TIME_POINT = 'time_point',
+    CHECKSUM256 = 'checksum256'
 }
 
 type ContentValueType<T,V> = [T, V];
@@ -29,10 +30,11 @@ type ContentValueAsset = ContentValueStringType<ContentType.ASSET>;
 type ContentValueName = ContentValueStringType<ContentType.NAME>;
 type ContentValueTimePoint = ContentValueStringType<ContentType.TIME_POINT>;
 type ContentValueInt64 = ContentValueNumberType<ContentType.INT64>;
+type ContentValueChecksum256 = ContentValueStringType<ContentType.CHECKSUM256>;
 
 export type ContentValue = 
 // string
-ContentValueString | ContentValueAsset | ContentValueName | ContentValueTimePoint
+ContentValueString | ContentValueAsset | ContentValueName | ContentValueTimePoint | ContentValueChecksum256
 // number
 | ContentValueInt64;
 
@@ -48,12 +50,14 @@ const makeContent = (label: string, value: ContentValue): Content => ({
 
 export const CONTENT_GROUP_LABEL = 'content_group_label';
 export const SYSTEM_CONTENT_GROUP_LABEL = 'system';
+export const DETAILS_CONTENT_GROUP_LABEL = 'details';
 
 export const makeStringContent = (label: string, value: string): Content  => makeContent(label, [ ContentType.STRING, value ]);
 export const makeAssetContent = (label: string, value: string): Content  => makeContent(label, [ ContentType.ASSET, value ]);
 export const makeNameContent = (label: string, value: string): Content  => makeContent(label, [ ContentType.NAME, value ]);
 export const makeTimePointContent = (label: string, value: string): Content  => makeContent(label, [ ContentType.TIME_POINT, value ]);
 export const makeInt64Content = (label: string, value: number): Content  => makeContent(label, [ ContentType.INT64, value ]);
+export const makeChecksum256Content = (label: string, value: string): Content  => makeContent(label, [ ContentType.CHECKSUM256, value ]);
 
 export const makeContentGroup = (groupLabel: string | undefined, ...content: ContentGroup) : ContentGroup => {
     return [

--- a/tests/utils/Dao.ts
+++ b/tests/utils/Dao.ts
@@ -1,4 +1,4 @@
-import { ContentGroup, ContentType, CONTENT_GROUP_LABEL, Document, SYSTEM_CONTENT_GROUP_LABEL } from "../types/Document"
+import { Content, ContentGroup, ContentType, CONTENT_GROUP_LABEL, DETAILS_CONTENT_GROUP_LABEL, Document, SYSTEM_CONTENT_GROUP_LABEL } from "../types/Document"
 import { Edge } from "../types/Edge";
 
 const TYPE_LABEL = 'type';
@@ -15,6 +15,18 @@ export const getContentGroupByLabel = (document: Document, groupLabel: string): 
 
 export const getSystemContentGroup = (document: Document): ContentGroup | undefined => {
     return getContentGroupByLabel(document, SYSTEM_CONTENT_GROUP_LABEL);
+}
+
+export const getDetailsGroup = (document: Document): ContentGroup | undefined => {
+  const group = getContentGroupByLabel(document, DETAILS_CONTENT_GROUP_LABEL);
+  if (group === undefined) {
+    throw Error('Missing details group from document');
+  }
+  return group;
+}
+
+export const getContent = (group: ContentGroup, label: string): Content | undefined => {
+  return group.find(item => item.label === label);
 }
 
 export const getDocumentsByType = (documents: Array<Document>, documentType: string): Array<Document> => {

--- a/tests/utils/Date.ts
+++ b/tests/utils/Date.ts
@@ -1,3 +1,5 @@
+import { DaoBlockchain } from "../dao/DaoBlockchain";
+
 export const toISOString = (date: Date) => {
     // The testing framework always rounds the  millis and doesn't have the Z
     // 22:47:12.867Z becomes 22:47:13
@@ -6,3 +8,19 @@ export const toISOString = (date: Date) => {
     copy.setMilliseconds(0);
     return copy.toISOString().split('.')[0] + '.000';
 };
+
+export const nextDay = (environment: DaoBlockchain, date: Date, offsetMinutes: number = 10) => {
+  // Sets the time to the end of proposal
+  const tomorrow = new Date();
+  tomorrow.setDate(date.getDate() + 1);
+  tomorrow.setMinutes(tomorrow.getMinutes() + offsetMinutes);
+  environment.setCurrentTime(tomorrow);
+  return tomorrow;
+}
+
+export const setDate = (environment: DaoBlockchain, date: Date, offsetMinutes: number = 10) => {
+  const next = new Date(date);
+  next.setMinutes(next.getMinutes() + offsetMinutes);
+  environment.setCurrentTime(next);
+  return next;
+}

--- a/tests/utils/DocumentBuilder.ts
+++ b/tests/utils/DocumentBuilder.ts
@@ -1,4 +1,4 @@
-import { ContentGroup, ContentGroups, Document, makeAssetContent, makeContentGroup, makeInt64Content, makeNameContent, makeStringContent, makeTimePointContent } from "../types/Document";
+import { ContentGroup, ContentGroups, Document, makeAssetContent, makeChecksum256Content, makeContentGroup, makeInt64Content, makeNameContent, makeStringContent, makeTimePointContent } from "../types/Document";
 
 type BuilderFunction<T> = (builder: T) => void;
 
@@ -103,6 +103,14 @@ class ContentGroupBuilder {
             makeAssetContent(label, value)
         );
         return this;
+    }
+
+    public checksum256(label: string, value: string): ContentGroupBuilder {
+      this._contentGroup.push(
+        makeChecksum256Content(label, value)
+      )
+
+      return this;
     }
 
     public name(label: string, value: string): ContentGroupBuilder {

--- a/tests/utils/Proposal.ts
+++ b/tests/utils/Proposal.ts
@@ -1,0 +1,42 @@
+import { DaoBlockchain } from "../dao/DaoBlockchain";
+import { last } from "./Arrays";
+import { Document } from '../types/Document';
+import { getContent, getContentGroupByLabel, getDocumentsByType } from "./Dao";
+import { setDate } from "./Date";
+
+export const proposeAndPass = 
+async (proposal: Document, type: string, date: Date, environment: DaoBlockchain): Promise<Document> => {
+  
+  await environment.dao.contract.propose({
+      proposer: environment.members[0].account.accountName,
+      proposal_type: type,
+      ...proposal
+  });
+
+  let propDoc = last(getDocumentsByType(
+      environment.getDaoDocuments(),
+      type
+  ));
+
+  for (let i = 0; i < environment.members.length; ++i) {
+    await environment.dao.contract.vote({
+      voter: environment.members[i].account.accountName,
+      proposal_hash: propDoc.hash,
+      vote: 'pass',
+      notes: 'votes pass'
+    });
+  }
+
+  const expiration = getContent(getContentGroupByLabel(propDoc, "ballot"), "expiration");
+
+  date = setDate(environment, new Date(expiration.value[1]));
+
+  await environment.dao.contract.closedocprop({
+    proposal_hash: propDoc.hash
+  }, environment.members[0].getPermissions());
+
+  return last(getDocumentsByType(
+    environment.getDaoDocuments(),
+    type
+  ));
+}


### PR DESCRIPTION
- Enables suspending roles
- Adds state field to all proposals
- Enables withdrawing from assignment when the current commitment is 0
- Disables adjusting commitment for 'withdrawed/suspended' assignments
- Fix suspension title

As suggested by @josejulio I squashed the commits from hotfix/suspend_role branch into a new one since there were some commits that appeared to be duplicated (probably due rebasing).