### PR TITLE
Remove unused declaration in proposal files

### DIFF
--- a/include/proposals/ass_extend_proposal.hpp
+++ b/include/proposals/ass_extend_proposal.hpp
@@ -12,9 +12,6 @@ namespace hypha {
     public:
         using Proposal::Proposal;
 
-        Document propose(const name &proposer, ContentGroups &contentGroups);
-        void close(Document &proposal);
-
     protected:
 
         void proposeImpl(const name &proposer, ContentWrapper &contentWrapper) override;

--- a/include/proposals/assignment_proposal.hpp
+++ b/include/proposals/assignment_proposal.hpp
@@ -14,9 +14,6 @@ namespace hypha {
     public:
         using Proposal::Proposal;
 
-        Document propose(const name &proposer, ContentGroups &contentGroups);
-        void close(Document &proposal);
-
     protected:
 
         void proposeImpl(const name &proposer, ContentWrapper &contentWrapper) override;

--- a/include/proposals/attestation_proposal.hpp
+++ b/include/proposals/attestation_proposal.hpp
@@ -12,9 +12,6 @@ namespace hypha {
     public:
         using Proposal::Proposal;
 
-        Document propose(const name &proposer, ContentGroups &contentGroups);
-        void close(Document &proposal);
-
     protected:
 
         void proposeImpl(const name &proposer, ContentWrapper &contentWrapper) override;

--- a/include/proposals/badge_assignment_proposal.hpp
+++ b/include/proposals/badge_assignment_proposal.hpp
@@ -12,10 +12,7 @@ namespace hypha {
 
     public:
         using Proposal::Proposal;
-
-        Document propose(const name &proposer, ContentGroups &contentGroups);
-        void close(Document &proposal);
-
+        
     protected:
         
         void proposeImpl(const name &proposer, ContentWrapper &contentWrapper) override;

--- a/include/proposals/badge_proposal.hpp
+++ b/include/proposals/badge_proposal.hpp
@@ -16,9 +16,6 @@ namespace hypha {
     public:
         using Proposal::Proposal;
 
-        Document propose(const eosio::name &proposer, ContentGroups &contentGroups);
-        void close(Document &proposal);
-
     protected:
         void proposeImpl(const eosio::name &proposer, ContentWrapper &contentWrapper) override;
         void passImpl(Document &proposal) override;

--- a/include/proposals/edit_proposal.hpp
+++ b/include/proposals/edit_proposal.hpp
@@ -11,10 +11,7 @@ namespace hypha {
     
     public:
         using Proposal::Proposal;
-
-        Document propose(const name &proposer, ContentGroups &contentGroups);
-        void close(Document &proposal);
-
+        
     protected:
 
         void proposeImpl(const name &proposer, ContentWrapper &contentWrapper) override;

--- a/include/proposals/payout_proposal.hpp
+++ b/include/proposals/payout_proposal.hpp
@@ -13,9 +13,6 @@ namespace hypha
     public:
         using Proposal::Proposal;
 
-        Document propose(const name &proposer, ContentGroups &contentGroups);
-        void close(Document &proposal);
-
     protected:
         void proposeImpl(const name &proposer, ContentWrapper &contentWrapper) override;
         void passImpl(Document &proposal) override;

--- a/include/proposals/role_proposal.hpp
+++ b/include/proposals/role_proposal.hpp
@@ -12,9 +12,6 @@ namespace hypha {
     public:
         using Proposal::Proposal;
 
-        Document propose(const name &proposer, ContentGroups &contentGroups);
-        void close(Document &proposal);
-
     protected:
 
         void proposeImpl(const name &proposer, ContentWrapper &contentWrapper) override;

--- a/include/proposals/suspend_proposal.hpp
+++ b/include/proposals/suspend_proposal.hpp
@@ -11,8 +11,6 @@ namespace hypha {
     
     public:
         using Proposal::Proposal;
-        Document propose(const name &proposer, ContentGroups &contentGroups);
-        void close(Document &proposal);
 
     protected:
 


### PR DESCRIPTION
All proposals were declaring `propose` and `close`, but it wasn't being implemented.

This could cause confusion when extending / reading the code.

@Gerard097 could you review?