### PR TITLE
Fixed reassigning badge

### DIFF
--- a/src/proposals/badge_assignment_proposal.cpp
+++ b/src/proposals/badge_assignment_proposal.cpp
@@ -69,9 +69,10 @@ namespace hypha
         //    badge_assignment  ---- start          ---->   period
 
         // the assignee now HOLDS this badge, non-strict in case the member already has the badge
-        Edge::write(m_dao.get_self(), m_dao.get_self(), assignee, badge.getHash(), common::HOLDS_BADGE);
+        //We use getOrNew since the user could have held this badge already
+        Edge::getOrNew(m_dao.get_self(), m_dao.get_self(), assignee, badge.getHash(), common::HOLDS_BADGE);
+        Edge::getOrNew(m_dao.get_self(), m_dao.get_self(), badge.getHash(), assignee, common::HELD_BY);
         Edge::write(m_dao.get_self(), m_dao.get_self(), assignee, proposal.getHash(), common::ASSIGN_BADGE);
-        Edge::write(m_dao.get_self(), m_dao.get_self(), badge.getHash(), assignee, common::HELD_BY);
         Edge::write(m_dao.get_self(), m_dao.get_self(), badge.getHash(), proposal.getHash(), common::ASSIGNMENT);
         Edge::write(m_dao.get_self(), m_dao.get_self(), proposal.getHash(), badge.getHash(), common::BADGE_NAME);
 


### PR DESCRIPTION
- `closedocprop` action failed the for users that tried to apply to a badge for a second time.