### PR TITLE
Accept HUSD and issue HYPHA

### DIFF
--- a/include/dao.hpp
+++ b/include/dao.hpp
@@ -165,6 +165,17 @@ namespace hypha
                             std::optional<eosio::time_point> fixedStartDate,
                             std::string_view modifier);
 
+      [[eosio::on_notify("husd.hypha::transfer")]]
+      void onhusd(const name& from, const name& to, const asset& quantity, const string& memo) {
+         if (get_first_receiver() == "husd.hypha"_n && 
+            to == get_self() && 
+            quantity.symbol == common::S_HUSD ) 
+         {
+            on_husd(from, to, quantity, memo);
+         }
+
+      }
+
    private:
       DocumentGraph m_documentGraph = DocumentGraph(get_self());
 
@@ -185,5 +196,8 @@ namespace hypha
       std::vector<Document> getCurrentBadges(Period & period, const eosio::name &member);
 
       bool isPaused();
+
+      void on_husd(const name& from, const name& to, const asset& quantity, const string& memo);
+
    };
 } // namespace hypha

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,8 +3,8 @@ project(dao)
 set(EOSIO_WASM_OLD_BEHAVIOR "Off")
 find_package(eosio.cdt)
 
-# Activate Logging
-add_compile_definitions(USE_LOGGING)
+# Activate Logging (disabled)
+# add_compile_definitions(USE_LOGGING)
 
 add_contract( dao dao 
                 dao.cpp

--- a/src/dao.cpp
+++ b/src/dao.cpp
@@ -965,12 +965,12 @@ namespace hypha
       EOS_CHECK(quantity.amount > 0, "quantity must be > 0");
       EOS_CHECK(quantity.is_valid(), "quantity invalid");
       
-      asset hyphaUsdVal = getSettingOrFail<eosio::asset>(common::HYPHA_USD_VALUE); // 0.5000 USD
+      asset hyphaUsdVal = getSettingOrFail<eosio::asset>(common::HYPHA_USD_VALUE);
       EOS_CHECK(
          hyphaUsdVal.symbol.precision() == 4,
          util::to_str("Expected hypha_usd_value precision to be 4, but got:", hyphaUsdVal.symbol.precision())
       );
-      double factor = (hyphaUsdVal.amount / 10000.0); // 0.5
+      double factor = (hyphaUsdVal.amount / 10000.0);
       
       EOS_CHECK(common::S_HUSD.precision() == common::S_HYPHA.precision(), "unexpected precision mismatch");
 

--- a/src/dao.cpp
+++ b/src/dao.cpp
@@ -884,6 +884,36 @@ namespace hypha
     m_documentGraph.updateDocument(issuer, assignment_hash, cw.getContentGroups());
   }
 
+   void dao::on_husd(const name& from, const name& to, const asset& quantity, const string& memo) {
+      
+      EOS_CHECK(quantity.amount > 0, "quantity must be > 0");
+      EOS_CHECK(quantity.is_valid(), "quantity invalid");
+      
+      asset hyphaUsdVal = getSettingOrFail<eosio::asset>(common::HYPHA_USD_VALUE); // 0.5000 USD
+      EOS_CHECK(
+         hyphaUsdVal.symbol.precision() == 4,
+         util::to_str("Expected HYPHA_USD_VALUE precision to be 4, but got:", hyphaUsdVal.symbol.precision())
+      );
+      double factor = (hyphaUsdVal.amount / 10000.0); // 0.5
+      
+      eosio::print("factor" + std::to_string(factor));
+
+      EOS_CHECK(common::S_HUSD.precision() == common::S_HYPHA.precision(), "unexpected precision mismatch");
+
+      asset hyphaAmount = asset( quantity.amount / factor, common::S_HYPHA);
+
+      eosio::print("hyphaAmount" + hyphaAmount.to_string());
+      
+      hypha::issueToken(
+         getSettingOrFail<eosio::name>(HYPHA_TOKEN_CONTRACT),
+         get_self(),
+         from,
+         hyphaAmount,
+         string("Buy HYPHA for " + quantity.to_string())
+      );
+
+   }
+
    void dao::modifyCommitment(Assignment& assignment, int64_t commitment, std::optional<eosio::time_point> fixedStartDate, std::string_view modifier)
    {
       TRACE_FUNCTION()

--- a/src/dao.cpp
+++ b/src/dao.cpp
@@ -884,36 +884,6 @@ namespace hypha
     m_documentGraph.updateDocument(issuer, assignment_hash, cw.getContentGroups());
   }
 
-   void dao::on_husd(const name& from, const name& to, const asset& quantity, const string& memo) {
-      
-      EOS_CHECK(quantity.amount > 0, "quantity must be > 0");
-      EOS_CHECK(quantity.is_valid(), "quantity invalid");
-      
-      asset hyphaUsdVal = getSettingOrFail<eosio::asset>(common::HYPHA_USD_VALUE); // 0.5000 USD
-      EOS_CHECK(
-         hyphaUsdVal.symbol.precision() == 4,
-         util::to_str("Expected HYPHA_USD_VALUE precision to be 4, but got:", hyphaUsdVal.symbol.precision())
-      );
-      double factor = (hyphaUsdVal.amount / 10000.0); // 0.5
-      
-      eosio::print("factor" + std::to_string(factor));
-
-      EOS_CHECK(common::S_HUSD.precision() == common::S_HYPHA.precision(), "unexpected precision mismatch");
-
-      asset hyphaAmount = asset( quantity.amount / factor, common::S_HYPHA);
-
-      eosio::print("hyphaAmount" + hyphaAmount.to_string());
-      
-      hypha::issueToken(
-         getSettingOrFail<eosio::name>(HYPHA_TOKEN_CONTRACT),
-         get_self(),
-         from,
-         hyphaAmount,
-         string("Buy HYPHA for " + quantity.to_string())
-      );
-
-   }
-
    void dao::modifyCommitment(Assignment& assignment, int64_t commitment, std::optional<eosio::time_point> fixedStartDate, std::string_view modifier)
    {
       TRACE_FUNCTION()
@@ -989,4 +959,31 @@ namespace hypha
 
       Edge::write(get_self(), get_self(), assignment.getHash(), newTimeShareDoc.getHash(), common::LAST_TIME_SHARE);
    }
+
+   void dao::on_husd(const name& from, const name& to, const asset& quantity, const string& memo) {
+      
+      EOS_CHECK(quantity.amount > 0, "quantity must be > 0");
+      EOS_CHECK(quantity.is_valid(), "quantity invalid");
+      
+      asset hyphaUsdVal = getSettingOrFail<eosio::asset>(common::HYPHA_USD_VALUE); // 0.5000 USD
+      EOS_CHECK(
+         hyphaUsdVal.symbol.precision() == 4,
+         util::to_str("Expected hypha_usd_value precision to be 4, but got:", hyphaUsdVal.symbol.precision())
+      );
+      double factor = (hyphaUsdVal.amount / 10000.0); // 0.5
+      
+      EOS_CHECK(common::S_HUSD.precision() == common::S_HYPHA.precision(), "unexpected precision mismatch");
+
+      asset hyphaAmount = asset( quantity.amount / factor, common::S_HYPHA);
+      
+      hypha::issueToken(
+         getSettingOrFail<eosio::name>(HYPHA_TOKEN_CONTRACT),
+         get_self(),
+         from,
+         hyphaAmount,
+         string("Buy HYPHA for " + quantity.to_string())
+      );
+
+   }
+
 } // namespace hypha


### PR DESCRIPTION
added on_notify for HUSD - issuing HYPHA when HUSD arrive, depending on current HYPHA - USD rate.

Tested and verified - tested by running local

Disables logging because the code size is too big with logging enabled (> 5MB).