### PR TITLE
Replaces likes with Reaction document

### DIFF
--- a/include/comments/likeable.hpp
+++ b/include/comments/likeable.hpp
@@ -8,8 +8,7 @@ namespace hypha
     {
         public:
             virtual ~Likeable();
-            const void like(eosio::name user);
+            const void like(eosio::name user, eosio::name reaction);
             const void unlike(eosio::name user);
-            const void updateContent(ContentWrapper& wrapper);
     };
 }

--- a/include/comments/reaction.hpp
+++ b/include/comments/reaction.hpp
@@ -1,0 +1,29 @@
+#pragma once
+#include <typed_document.hpp>
+#include <string>
+#include <eosio/name.hpp>
+
+namespace hypha
+{
+    class dao;
+    class Likeable;
+
+    class Reaction: public TypedDocument
+    {
+        public:
+            Reaction(dao& dao, uint64_t id);
+            Reaction(
+                dao&dao,
+                Likeable& likeable,
+                const eosio::name who,
+                const eosio::name reaction
+            );
+
+            void remove();
+
+            static Reaction getReaction(dao& dao, Likeable& likeable, const eosio::name who);
+
+        protected:
+            virtual const std::string buildNodeLabel(ContentGroups &content);
+    };
+}

--- a/include/comments/reaction.hpp
+++ b/include/comments/reaction.hpp
@@ -3,6 +3,25 @@
 #include <string>
 #include <eosio/name.hpp>
 
+// Reaction edges
+// Member1 Liked Proposal1 and Loved Proposal2
+// Member2 Loved Proposal3
+//
+//                                    ┌───────reaction─┐
+//                                    ▼                ▼
+//                  ┌reactionlink─►LIKED-P1    ┌───►Proposal1
+//                  ▼                          │
+//         ┌─►Member1◄────────reactedto────────┤
+//         │                                   │
+//         │                                   └───►Proposal2◄─┐
+//         │                                                   │
+//         │  Member2◄────────reactedto──────────────┐         │
+//         │      ▲                                  ▼         │
+//         │      reactionlink►LOVED-P3◄──────┐     Proposal3  │
+//         │                                  │         ▲      │
+//         └──reactionlink─┐                 reaction───┘      │
+//                         └────►LOVED-P2◄─────┐               │
+//                                             └─reaction──────┘
 namespace hypha
 {
     class dao;
@@ -15,15 +34,18 @@ namespace hypha
             Reaction(
                 dao&dao,
                 Likeable& likeable,
-                const eosio::name who,
                 const eosio::name reaction
             );
 
             void remove();
+            void react(eosio::name who);
+            void unreact(eosio::name who);
 
-            static Reaction getReaction(dao& dao, Likeable& likeable, const eosio::name who);
+            static Reaction getReaction(dao& dao, Likeable& likeable, const eosio::name reaction);
+            static Reaction getReactionByUser(dao& dao, Likeable& likeable, const eosio::name who);
 
         protected:
             virtual const std::string buildNodeLabel(ContentGroups &content);
+            uint64_t getLikeableId();
     };
 }

--- a/include/common.hpp
+++ b/include/common.hpp
@@ -125,8 +125,8 @@ namespace common
     constexpr name COMMENT_SECTION = name("cmntsect");
     constexpr name COMMENT_SECTION_OF = name("cmntsectof");
 
-    constexpr name REACTED = name("reacted");
     constexpr name REACTED_TO = name("reactedto");
+    constexpr name REACTED_BY = name("reactedby");
     constexpr name REACTION = name("reaction");
     constexpr name REACTION_OF = name("reactionof");
 
@@ -161,7 +161,7 @@ namespace common
             kENABLED,
             kID
       };
-    }    
+    }
 
     constexpr name LAST_TIME_SHARE = name("lastimeshare");
     constexpr name CURRENT_TIME_SHARE = name("curtimeshare");

--- a/include/common.hpp
+++ b/include/common.hpp
@@ -129,6 +129,8 @@ namespace common
     constexpr name REACTED_BY = name("reactedby");
     constexpr name REACTION = name("reaction");
     constexpr name REACTION_OF = name("reactionof");
+    constexpr name REACTION_LINK = name("reactionlnk");
+    constexpr name REACTION_LINK_REVERSE = name("reactionlnkr");
 
 
     // document types

--- a/include/common.hpp
+++ b/include/common.hpp
@@ -125,6 +125,12 @@ namespace common
     constexpr name COMMENT_SECTION = name("cmntsect");
     constexpr name COMMENT_SECTION_OF = name("cmntsectof");
 
+    constexpr name REACTED = name("reacted");
+    constexpr name REACTED_TO = name("reactedto");
+    constexpr name REACTION = name("reaction");
+    constexpr name REACTION_OF = name("reactionof");
+
+
     // document types
     constexpr name ALERT = name ("alert");
     constexpr name NOTIFIES = name ("notifies");

--- a/include/dao.hpp
+++ b/include/dao.hpp
@@ -84,11 +84,13 @@ namespace hypha
 
       // comment related
       ACTION cmntmigrate(const uint64_t &dao_id);
-      ACTION cmntlike(const name &user, const uint64_t comment_section_id);
-      ACTION cmntunlike(const name &user, const uint64_t comment_section_id);
       ACTION cmntadd(const name &author, const string content, const uint64_t comment_or_section_id);
       ACTION cmntupd(const string new_content, const uint64_t comment_id);
       ACTION cmntrem(const uint64_t comment_id);
+
+      // reaction related
+      ACTION reactadd(const name &user, const name &reaction, const uint64_t document_id);
+      ACTION reactrem(const name &user, const uint64_t document_id);
 
       //Sets a dho/contract level setting
       ACTION setsetting(const string &key, const Content::FlexValue &value, std::optional<std::string> group);

--- a/include/typed_document.hpp
+++ b/include/typed_document.hpp
@@ -42,5 +42,6 @@ namespace hypha
         constexpr eosio::name VOTE_TALLY = eosio::name("vote.tally");
         constexpr eosio::name COMMENT = eosio::name("comment");
         constexpr eosio::name COMMENT_SECTION = eosio::name("cmnt.section");
+        constexpr eosio::name REACTION = eosio::name("reaction");
     }
 }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -41,6 +41,7 @@ add_contract( dao dao
                 comments/likeable.cpp
                 comments/comment.cpp
                 comments/section.cpp
+                comments/reaction.cpp
                 ../document-graph/src/document_graph/document_graph.cpp
                 ../document-graph/src/document_graph/document.cpp
                 ../document-graph/src/document_graph/content_wrapper.cpp

--- a/src/ballots/vote.cpp
+++ b/src/ballots/vote.cpp
@@ -126,7 +126,7 @@ namespace hypha
             CONTENT_GROUP_LABEL_VOTE,
             VOTE_LABEL,
             "Vote does not have " CONTENT_GROUP_LABEL_VOTE " content group"
-        )->template getAs<std::string>();
+        )->getAs<std::string>();
     }
 
     const eosio::asset& Vote::getPower()

--- a/src/comments/comment.cpp
+++ b/src/comments/comment.cpp
@@ -13,7 +13,6 @@ namespace hypha
     const std::string ENTRY_CONTENT = "content";
     const std::string ENTRY_EDITED = "edited";
     const std::string ENTRY_DELETED = "deleted";
-    const std::string ENTRY_COMMENT_COUNT = "comment_count";
 
     Comment::Comment(dao& dao, uint64_t id) : TypedDocument(dao, id, TYPED_DOCUMENT_TYPE)
     {
@@ -81,8 +80,7 @@ namespace hypha
             ContentGroup{
                 Content(CONTENT_GROUP_LABEL, GROUP_COMMENT),
                 Content(ENTRY_AUTHOR, author),
-                Content(ENTRY_CONTENT, content),
-                Content(ENTRY_COMMENT_COUNT, 0)
+                Content(ENTRY_CONTENT, content)
             }
         };
         initializeDocument(dao, contentGroups);

--- a/src/comments/likeable.cpp
+++ b/src/comments/likeable.cpp
@@ -11,12 +11,12 @@ namespace hypha
     const void Likeable::like(name user, name type)
     {
         TRACE_FUNCTION()
-        Reaction reaction(this->getDao(), *this, user, type);
+        Reaction(this->getDao(), *this, type).react(user);
     }
 
     const void Likeable::unlike(name user)
     {
         TRACE_FUNCTION()
-        Reaction::getReaction(this->getDao(), *this, user).remove();
+        Reaction::getReactionByUser(this->getDao(), *this, user).unreact(user);
     }
 }

--- a/src/comments/likeable.cpp
+++ b/src/comments/likeable.cpp
@@ -1,62 +1,22 @@
 #include <comments/likeable.hpp>
+#include <comments/reaction.hpp>
 #include <dao.hpp>
 
 namespace hypha
 {
-
-    const std::string GROUP_LIKE_DETAILS = "like-details";
-    const std::string ENTRY_LIKES = "likes";
-
-    const std::string GROUP_LIKES = "likes";
-
     Likeable::~Likeable()
     {
     }
 
-    const void Likeable::like(name user)
+    const void Likeable::like(name user, name type)
     {
         TRACE_FUNCTION()
-
-        auto content_wrapper = this->getDocument().getContentWrapper();
-        auto like_group = content_wrapper.getGroup(GROUP_LIKES);
-
-        auto content_pair = content_wrapper.get(like_group.first, user.to_string());
-
-        eosio::check(content_pair.first == -1, "User already likes this comment section");
-        content_wrapper.insertOrReplace(like_group.first, Content(user.to_string(), true));
-
-        auto details_group = content_wrapper.getGroup(GROUP_LIKE_DETAILS);
-        auto likes = content_wrapper.getOrFail(details_group.first, ENTRY_LIKES).second;
-        content_wrapper.insertOrReplace(details_group.first, Content(ENTRY_LIKES, likes->getAs<int64_t>() + 1));
-
-        this->update();
+        Reaction reaction(this->getDao(), *this, user, type);
     }
 
     const void Likeable::unlike(name user)
     {
         TRACE_FUNCTION()
-
-        auto content_wrapper = this->getDocument().getContentWrapper();
-        auto like_group = content_wrapper.getGroup(GROUP_LIKES);
-
-        auto content_pair = content_wrapper.get(like_group.first, user.to_string());
-
-        eosio::check(content_pair.first != -1, "User does not like this comment section");
-        content_wrapper.removeContent(like_group.first, user.to_string());
-
-        auto details_group = content_wrapper.getGroup(GROUP_LIKE_DETAILS);
-        auto likes = content_wrapper.getOrFail(details_group.first, ENTRY_LIKES).second;
-        content_wrapper.insertOrReplace(details_group.first, Content(ENTRY_LIKES, likes->getAs<int64_t>() - 1));
-
-        this->update();
-    }
-
-    const void Likeable::updateContent(ContentWrapper& wrapper)
-    {
-        TRACE_FUNCTION()
-        TypedDocument::updateContent(wrapper);
-        auto group = wrapper.getGroupOrCreate(GROUP_LIKE_DETAILS);
-        wrapper.insertOrReplace(*group.second, Content(ENTRY_LIKES, 0));
-        wrapper.getGroupOrCreate(GROUP_LIKES);
+        Reaction::getReaction(this->getDao(), *this, user).remove();
     }
 }

--- a/src/comments/likeable.cpp
+++ b/src/comments/likeable.cpp
@@ -11,7 +11,7 @@ namespace hypha
     const void Likeable::like(name user, name type)
     {
         TRACE_FUNCTION()
-        Reaction(this->getDao(), *this, type).react(user);
+        Reaction::getReaction(this->getDao(), *this, type).react(user);
     }
 
     const void Likeable::unlike(name user)

--- a/src/comments/reaction.cpp
+++ b/src/comments/reaction.cpp
@@ -36,7 +36,7 @@ namespace hypha
 
         uint64_t memberId = dao.getMemberID(who);
         EOS_CHECK(
-            !Edge::exists(dao.get_self(), memberId, likeable.getId(), common::REACTED),
+            !Edge::exists(dao.get_self(), memberId, likeable.getId(), common::REACTED_TO),
             "Member already reacted to this document"
         );
         EOS_CHECK(
@@ -53,8 +53,8 @@ namespace hypha
         };
 
         initializeDocument(dao, contentGroups);
-        Edge::getOrNew(dao.get_self(), who, memberId, likeable.getId(), common::REACTED);
-        Edge::getOrNew(dao.get_self(), who, likeable.getId(), memberId, common::REACTED_TO);
+        Edge::getOrNew(dao.get_self(), who, memberId, likeable.getId(), common::REACTED_TO);
+        Edge::getOrNew(dao.get_self(), who, likeable.getId(), memberId, common::REACTED_BY);
         Edge::getOrNew(dao.get_self(), who, likeable.getId(), this->getId(), common::REACTION);
         Edge::getOrNew(dao.get_self(), who, this->getId(), likeable.getId(), common::REACTION_OF);
 
@@ -69,12 +69,12 @@ namespace hypha
         )->getAs<eosio::name>();
 
         uint64_t memberId = getDao().getMemberID(who);
-        uint64_t likeableId = Edge::get(getDao().get_self(), memberId, common::REACTED).getToNode();
+        uint64_t likeableId = Edge::get(getDao().get_self(), memberId, common::REACTED_TO).getToNode();
 
-        std::vector<Edge> reactions = getDao().getGraph().getEdgesFrom(likeableId, common::REACTED);
+        std::vector<Edge> reactions = getDao().getGraph().getEdgesFrom(likeableId, common::REACTED_TO);
         for (auto reaction : reactions) {
             if (reaction.getCreator() == who) {
-                Edge::get(getDao().get_self(), reaction.getToNode(), reaction.getFromNode(), common::REACTED_TO).erase();
+                Edge::get(getDao().get_self(), reaction.getToNode(), reaction.getFromNode(), common::REACTED_BY).erase();
                 reaction.erase();
                 break;
             }

--- a/src/comments/reaction.cpp
+++ b/src/comments/reaction.cpp
@@ -1,0 +1,116 @@
+#include <comments/reaction.hpp>
+#include <comments/likeable.hpp>
+#include <dao.hpp>
+#include <document_graph/edge.hpp>
+
+#define TYPED_DOCUMENT_TYPE document_types::REACTION
+#define CONTENT_GROUP_LABEL_REACTION "reaction"
+#define CONTENT_REACTION_TYPE "type"
+#define CONTENT_REACTION_WHO "who"
+
+namespace hypha
+{
+    static constexpr eosio::name REACTION_LIKE("liked");
+
+
+    static bool is_reaction(eosio::name reaction)
+    {
+        return reaction == REACTION_LIKE;
+    }
+
+    Reaction::Reaction(hypha::dao& dao, uint64_t id)
+    : TypedDocument(dao, id, TYPED_DOCUMENT_TYPE)
+    {
+        TRACE_FUNCTION()
+    }
+
+    Reaction::Reaction(
+        dao&dao,
+        Likeable& likeable,
+        const eosio::name who,
+        const eosio::name reaction
+    )
+    : TypedDocument(dao, TYPED_DOCUMENT_TYPE)
+    {
+        TRACE_FUNCTION()
+
+        uint64_t memberId = dao.getMemberID(who);
+        EOS_CHECK(
+            !Edge::exists(dao.get_self(), memberId, likeable.getId(), common::REACTED),
+            "Member already reacted to this document"
+        );
+        EOS_CHECK(
+            is_reaction(reaction),
+            "Only like reaction currently supported"
+        );
+
+        ContentGroups contentGroups{
+            ContentGroup{
+                Content(CONTENT_GROUP_LABEL, CONTENT_GROUP_LABEL_REACTION),
+                Content(CONTENT_REACTION_TYPE, reaction),
+                Content(CONTENT_REACTION_WHO, who),
+            }
+        };
+
+        initializeDocument(dao, contentGroups);
+        Edge::getOrNew(dao.get_self(), who, memberId, likeable.getId(), common::REACTED);
+        Edge::getOrNew(dao.get_self(), who, likeable.getId(), memberId, common::REACTED_TO);
+        Edge::getOrNew(dao.get_self(), who, likeable.getId(), this->getId(), common::REACTION);
+        Edge::getOrNew(dao.get_self(), who, this->getId(), likeable.getId(), common::REACTION_OF);
+
+    }
+
+    void Reaction::remove()
+    {
+        eosio::name who = getDocument().getContentWrapper().getOrFail(
+            CONTENT_GROUP_LABEL_REACTION,
+            CONTENT_REACTION_WHO,
+            "Could not find who had this reaction, this is a bug."
+        )->getAs<eosio::name>();
+
+        uint64_t memberId = getDao().getMemberID(who);
+        uint64_t likeableId = Edge::get(getDao().get_self(), memberId, common::REACTED).getToNode();
+
+        std::vector<Edge> reactions = getDao().getGraph().getEdgesFrom(likeableId, common::REACTED);
+        for (auto reaction : reactions) {
+            if (reaction.getCreator() == who) {
+                Edge::get(getDao().get_self(), reaction.getToNode(), reaction.getFromNode(), common::REACTED_TO).erase();
+                reaction.erase();
+                break;
+            }
+        }
+
+        this->getDao().getGraph().removeEdges(getId());
+        this->erase();
+    }
+
+    Reaction Reaction::getReaction(dao& dao, Likeable& likeable, const eosio::name who)
+    {
+        std::vector<Edge> reactions = dao.getGraph().getEdgesFrom(likeable.getId(), common::REACTION);
+        for (auto reaction : reactions) {
+            if (reaction.getCreator() == who) {
+                return Reaction(dao, reaction.getToNode());
+            }
+        }
+
+        eosio::check(false, "No reaction found for user on document");
+        return Reaction(dao, 0);
+    }
+
+    const std::string Reaction::buildNodeLabel(ContentGroups &content)
+    {
+        eosio::name who = ContentWrapper(content).getOrFail(
+            CONTENT_GROUP_LABEL_REACTION,
+            CONTENT_REACTION_WHO,
+            "Could not find who had this reaction, this is a bug."
+        )->getAs<eosio::name>();
+
+        eosio::name type = ContentWrapper(content).getOrFail(
+            CONTENT_GROUP_LABEL_REACTION,
+            CONTENT_REACTION_TYPE,
+            "Could not find reaction_type, this is a bug."
+        )->getAs<eosio::name>();
+
+        return who.to_string() + " " + type.to_string() + " this document.";
+    }
+}

--- a/src/comments/reaction.cpp
+++ b/src/comments/reaction.cpp
@@ -110,6 +110,15 @@ namespace hypha
         Edge::get(getDao().get_self(), this->getId(), memberId, common::REACTION_LINK_REVERSE).erase();
     }
 
+    Reaction Reaction::getReaction(dao& dao, Likeable& likeable, const eosio::name reaction)
+    {
+        std::pair<bool, Edge> edgePair = Edge::getIfExists(dao.get_self(), likeable.getId(), common::REACTION);
+        if (edgePair.first) {
+            return Reaction(dao, edgePair.second.getToNode());
+        }
+
+        return Reaction(dao, likeable, reaction);
+    }
 
     Reaction Reaction::getReactionByUser(dao& dao, Likeable& likeable, const eosio::name who)
     {

--- a/src/dao.cpp
+++ b/src/dao.cpp
@@ -310,22 +310,6 @@ namespace hypha
 
   }
 
-  ACTION dao::cmntlike(const name& user, const uint64_t comment_section_id)
-  {
-    TRACE_FUNCTION();
-    EOS_CHECK(!isPaused(), "Contract is paused for maintenance. Please try again later.");
-    require_auth(user);
-    TypedDocumentFactory::getLikeableDocument(*this, comment_section_id)->like(user);
-  }
-
-  ACTION dao::cmntunlike(const name& user, const uint64_t comment_section_id)
-  {
-    TRACE_FUNCTION();
-    EOS_CHECK(!isPaused(), "Contract is paused for maintenance. Please try again later.");
-    require_auth(user);
-    TypedDocumentFactory::getLikeableDocument(*this, comment_section_id)->unlike(user);
-  }
-
   ACTION dao::cmntadd(const name& author, const string content, const uint64_t comment_or_section_id)
   {
     TRACE_FUNCTION();
@@ -377,6 +361,22 @@ namespace hypha
     require_auth(comment.getAuthor());
 
     comment.markAsDeleted();
+  }
+
+  ACTION dao::reactadd(const name &user, const name &reaction, const uint64_t document_id)
+  {
+    TRACE_FUNCTION()
+    EOS_CHECK(!isPaused(), "Contract is paused for maintenance. Please try again later.");
+    require_auth(user);
+    TypedDocumentFactory::getLikeableDocument(*this, document_id)->like(user, reaction);
+  }
+
+  ACTION dao::reactrem(const name &user, const uint64_t document_id)
+  {
+    TRACE_FUNCTION()
+    EOS_CHECK(!isPaused(), "Contract is paused for maintenance. Please try again later.");
+    require_auth(user);
+    TypedDocumentFactory::getLikeableDocument(*this, document_id)->unlike(user);
   }
 
   void dao::proposeextend(uint64_t assignment_id, const int64_t additional_periods)

--- a/tests/comments.test.ts
+++ b/tests/comments.test.ts
@@ -1,7 +1,7 @@
 import { setupEnvironment } from "./setup";
 import { Document } from './types/Document';
 import { last } from './utils/Arrays';
-import { getContent, getContentGroupByLabel, getDocumentsByType } from './utils/Dao';
+import {getContent, getContentGroupByLabel, getDocumentsByType, getEdgesByFilter} from './utils/Dao';
 import { DocumentBuilder } from './utils/DocumentBuilder';
 import { getDaoExpect } from './utils/Expect';
 import { getAccountPermission } from "./utils/Permissions";
@@ -179,6 +179,10 @@ describe('Proposal', () => {
             "reaction"
         ));
         checkReaction(reaction, dao.members[1].account.accountName, 'liked');
+        expect(getEdgesByFilter(environment.getDaoEdges(), {
+            edge_name: 'reaction',
+            from_node: comment.id
+        })).toHaveLength(1);
 
         // unlike comment acc1
         await environment.daoContract.contract.reactrem({

--- a/tests/comments.test.ts
+++ b/tests/comments.test.ts
@@ -87,8 +87,8 @@ describe('Proposal', () => {
         let firstReactionId = reaction.id;
 
         // likeable <-----> reaction
-        daoExpect.toHaveEdge(dao.members[0].doc, commentSection, 'reacted');
-        daoExpect.toHaveEdge(commentSection, dao.members[0].doc, 'reactedto');
+        daoExpect.toHaveEdge(dao.members[0].doc, commentSection, 'reactedto');
+        daoExpect.toHaveEdge(commentSection, dao.members[0].doc, 'reactedby');
 
         daoExpect.toHaveEdge(commentSection, reaction, 'reaction');
         daoExpect.toHaveEdge(reaction, commentSection, 'reactionof');

--- a/tests/comments.test.ts
+++ b/tests/comments.test.ts
@@ -25,7 +25,6 @@ describe('Proposal', () => {
 
     const checkReaction = (reaction: Document, who: string, what: string) => {
         const likeDetails = getContentGroupByLabel(reaction, 'reaction');
-        expect(getContent(likeDetails, 'who').value[1]).toBe(who);
         expect(getContent(likeDetails, 'type').value[1]).toBe(what);
     }
 
@@ -93,6 +92,9 @@ describe('Proposal', () => {
         daoExpect.toHaveEdge(commentSection, reaction, 'reaction');
         daoExpect.toHaveEdge(reaction, commentSection, 'reactionof');
 
+        daoExpect.toHaveEdge(dao.members[0].doc, reaction, 'reactionlnk');
+        daoExpect.toHaveEdge(reaction, dao.members[0].doc, 'reactionlnkr');
+
         checkReaction(reaction, dao.members[0].account.accountName, 'liked');
 
         await environment.daoContract.contract.reactadd({
@@ -122,7 +124,7 @@ describe('Proposal', () => {
 
         expect(getDocumentsByType(
             environment.getDaoDocuments(),
-            "reaction"
+            "reactionlnk"
         ).filter(d => d.id === firstReactionId).length).toBe(0);
 
         // add comment to a section

--- a/tests/comments.test.ts
+++ b/tests/comments.test.ts
@@ -23,9 +23,10 @@ describe('Proposal', () => {
     })
     .build();
 
-    const checkLikeCount = (likeable: Document, expectedLikes: number) => {
-        const likeDetails = getContentGroupByLabel(likeable, 'like-details');
-        expect(getContent(likeDetails, 'likes').value[1]).toBe(expectedLikes.toString());
+    const checkReaction = (reaction: Document, who: string, what: string) => {
+        const likeDetails = getContentGroupByLabel(reaction, 'reaction');
+        expect(getContent(likeDetails, 'who').value[1]).toBe(who);
+        expect(getContent(likeDetails, 'type').value[1]).toBe(what);
     }
 
     it('Proposals have a comment section', async() => {
@@ -57,53 +58,72 @@ describe('Proposal', () => {
             'cmnt.section'
         ));
 
-        checkLikeCount(commentSection, 0);
+
+        expect(getDocumentsByType(
+            environment.getDaoDocuments(),
+            "reaction"
+        ).length).toBe(0);
 
         // proposal <-----> comment section
         daoExpect.toHaveEdge(proposal, commentSection, 'cmntsect');
         daoExpect.toHaveEdge(commentSection, proposal, 'cmntsectof');
 
         // likes
-        await environment.daoContract.contract.cmntlike({
+        await environment.daoContract.contract.reactadd({
             user: dao.members[0].account.accountName,
-            comment_section_id: commentSection.id
+            reaction: 'liked',
+            document_id: commentSection.id
         }, getAccountPermission(dao.members[0].account));
+
         commentSection = last(getDocumentsByType(
             environment.getDaoDocuments(),
             'cmnt.section'
         ));
-        checkLikeCount(commentSection, 1);
-        let likes = getContentGroupByLabel(commentSection, 'likes')
-        expect(getContent(likes, dao.members[0].account.accountName)).toBeTruthy();
-        expect(getContent(likes, dao.members[1].account.accountName)).toBeUndefined();
 
-        await environment.daoContract.contract.cmntlike({
+        let reaction = last(getDocumentsByType(
+            environment.getDaoDocuments(),
+            "reaction"
+        ));
+        let firstReactionId = reaction.id;
+
+        // likeable <-----> reaction
+        daoExpect.toHaveEdge(dao.members[0].doc, commentSection, 'reacted');
+        daoExpect.toHaveEdge(commentSection, dao.members[0].doc, 'reactedto');
+
+        daoExpect.toHaveEdge(commentSection, reaction, 'reaction');
+        daoExpect.toHaveEdge(reaction, commentSection, 'reactionof');
+
+        checkReaction(reaction, dao.members[0].account.accountName, 'liked');
+
+        await environment.daoContract.contract.reactadd({
             user: dao.members[1].account.accountName,
-            comment_section_id: commentSection.id
+            reaction: 'liked',
+            document_id: commentSection.id
         }, getAccountPermission(dao.members[1].account));
         commentSection = last(getDocumentsByType(
             environment.getDaoDocuments(),
             'cmnt.section'
         ));
-        checkLikeCount(commentSection, 2);
-
-        likes = getContentGroupByLabel(commentSection, 'likes')
-        expect(getContent(likes, dao.members[0].account.accountName)).toBeTruthy();
-        expect(getContent(likes, dao.members[1].account.accountName)).toBeTruthy();
+        reaction = last(getDocumentsByType(
+            environment.getDaoDocuments(),
+            "reaction"
+        ));
+        checkReaction(reaction, dao.members[1].account.accountName, 'liked');
 
         // unlike
-        await environment.daoContract.contract.cmntunlike({
+        await environment.daoContract.contract.reactrem({
             user: dao.members[0].account.accountName,
-            comment_section_id: commentSection.id
+            document_id: commentSection.id
         }, getAccountPermission(dao.members[0].account));
         commentSection = last(getDocumentsByType(
             environment.getDaoDocuments(),
             'cmnt.section'
         ));
-        checkLikeCount(commentSection, 1);
-        likes = getContentGroupByLabel(commentSection, 'likes')
-        expect(getContent(likes, dao.members[0].account.accountName)).toBeUndefined();
-        expect(getContent(likes, dao.members[1].account.accountName)).toBeTruthy();
+
+        expect(getDocumentsByType(
+            environment.getDaoDocuments(),
+            "reaction"
+        ).filter(d => d.id === firstReactionId).length).toBe(0);
 
         // add comment to a section
         await environment.daoContract.contract.cmntadd({
@@ -115,7 +135,7 @@ describe('Proposal', () => {
             environment.getDaoDocuments(),
             'comment'
         ));
-        checkLikeCount(comment, 0);
+
         let commentContent = getContentGroupByLabel(comment, 'comment');
         expect(getContent(commentContent, 'author').value[1]).toBe(dao.members[0].account.accountName);
         expect(getContent(commentContent, 'content').value[1]).toBe('This is sweet!');
@@ -125,38 +145,48 @@ describe('Proposal', () => {
         daoExpect.toHaveEdge(comment, commentSection, 'commentof');
 
         // like comment acc0
-        await environment.daoContract.contract.cmntlike({
+        await environment.daoContract.contract.reactadd({
             user: dao.members[0].account.accountName,
-            comment_section_id: comment.id
+            reaction: 'liked',
+            document_id: comment.id
         }, getAccountPermission(dao.members[0].account));
         comment = last(getDocumentsByType(
             environment.getDaoDocuments(),
             'comment'
         ));
-        checkLikeCount(comment, 1);
+
+        reaction = last(getDocumentsByType(
+            environment.getDaoDocuments(),
+            "reaction"
+        ));
+        checkReaction(reaction, dao.members[0].account.accountName, 'liked');
 
         // like comment acc1
-        await environment.daoContract.contract.cmntlike({
+        await environment.daoContract.contract.reactadd({
             user: dao.members[1].account.accountName,
-            comment_section_id: comment.id
+            reaction: 'liked',
+            document_id: comment.id
         }, getAccountPermission(dao.members[1].account));
         comment = last(getDocumentsByType(
             environment.getDaoDocuments(),
             'comment'
         ));
-        checkLikeCount(comment, 2);
+
+        reaction = last(getDocumentsByType(
+            environment.getDaoDocuments(),
+            "reaction"
+        ));
+        checkReaction(reaction, dao.members[1].account.accountName, 'liked');
 
         // unlike comment acc1
-        await environment.daoContract.contract.cmntunlike({
+        await environment.daoContract.contract.reactrem({
             user: dao.members[1].account.accountName,
-            comment_section_id: comment.id
+            document_id: comment.id
         }, getAccountPermission(dao.members[1].account));
         comment = last(getDocumentsByType(
             environment.getDaoDocuments(),
             'comment'
         ));
-        checkLikeCount(comment, 1);
-
 
         // update
         await environment.daoContract.contract.cmntupd({


### PR DESCRIPTION
Removes the likes inside the `Likeable` document and moves them to a `Reaction` document.

The Comment/Section has bidirectional edges to the Reaction and the member has bidirectional edges to the Reaction too.