### PR TITLE
re enable add ram

### DIFF
--- a/include/common.hpp
+++ b/include/common.hpp
@@ -73,7 +73,7 @@ namespace hypha::common
     inline constexpr auto VOICE_TOKEN_DECAY_PER_PERIOD = "voice_token_decay_per_period_x10M";
     inline constexpr auto SKIP_PEG_TOKEN_CREATION = "skip_peg_token_create";
     inline constexpr auto SKIP_REWARD_TOKEN_CREATION = "skip_reward_token_create";
-    //const asset RAM_ALLOWANCE = asset(20000, symbol("TLOS", 4));
+    const uint32_t RAM_ALLOWANCE_BYTES = (uint32_t) 512;
     inline constexpr auto URLS_GROUP = "urls";
     inline constexpr auto URL = "url";
     inline constexpr auto CLAIM_ENABLED = "claim_enabled";

--- a/src/member.cpp
+++ b/src/member.cpp
@@ -120,11 +120,11 @@ namespace hypha
 
         Edge::write(getContract(), getAccount(), getID(), paymentReceipt.getID(), common::PAYMENT);
 
-        // eosio::action(
-        //     eosio::permission_level{getContract(), name("active")},
-        //     name("eosio"), name("buyram"),
-        //     std::make_tuple(getContract(), getAccount(), common::RAM_ALLOWANCE))
-        //     .send();
+        eosio::action(
+            eosio::permission_level{ getContract(), name("active") },
+            name("eosio"), name("buyrambytes"),
+            std::make_tuple(getContract(), getAccount(), common::RAM_ALLOWANCE_BYTES))
+            .send();
     }
 
     eosio::name Member::getAccount()


### PR DESCRIPTION
What is this for:

The enroll function in the DAO adds a small amount of RAM to new members - this prevents members ending up with non-functional account. 

Adding 512 bytes.