### PR TITLE
DUNES support: Added compiler option to setup script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ main1.go
 /dao-go/**/*.json
 dao-contracts
 migration.sh
+build_ninja

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,15 +4,15 @@ cmake_minimum_required(VERSION 3.16)
 
 include(ExternalProject)
 # if no cdt root is given use default path
-if(EOSIO_CDT_ROOT STREQUAL "" OR NOT EOSIO_CDT_ROOT)
-   find_package(eosio.cdt)
+if(CDT_ROOT STREQUAL "" OR NOT CDT_ROOT)
+   find_package(cdt)
 endif()
 
 ExternalProject_Add(
    dao_project
    SOURCE_DIR ${CMAKE_SOURCE_DIR}/src
    BINARY_DIR ${CMAKE_BINARY_DIR}/dao
-   CMAKE_ARGS -DCMAKE_TOOLCHAIN_FILE=${EOSIO_CDT_ROOT}/lib/cmake/eosio.cdt/EosioWasmToolchain.cmake
+   CMAKE_ARGS -DCMAKE_TOOLCHAIN_FILE=${CDT_ROOT}/lib/cmake/cdt/CDTWasmToolchain.cmake
    UPDATE_COMMAND ""
    PATCH_COMMAND ""
    TEST_COMMAND ""

--- a/include/config/config.hpp
+++ b/include/config/config.hpp
@@ -1,5 +1,5 @@
 #pragma once
 #define PRODUCTION_BUILD
 #define USE_TREASURY
-//#define USE_UPVOTE_ELECTIONS
-#define USE_PRICING_PLAN
+// #define USE_UPVOTE_ELECTIONS
+// #define USE_PRICING_PLAN

--- a/setup.sh
+++ b/setup.sh
@@ -1,7 +1,10 @@
 #!/bin/sh
 
 echoerr() { 
-    echo "\033[0;31m Error - Invalid arguments: \033[0m Expected one of the following (dev|eosdev|prod|eosprod|develop|production) i.e 'setup.sh dev'" 
+    echo "\033[0;31m Error - Invalid arguments: \033[0m $1"
+    echo "Expected one of the following modes of operation:"
+    echo "  Mode 1: setup.sh (dev|eosdev|prod|eosprod|develop|production)        (e.g., 'setup.sh dev')"
+    echo "  Mode 2: setup.sh compiler (docker|local) (e.g., 'setup.sh compiler docker')"
 }
 
 if [[ $# -eq 1 ]];
@@ -19,14 +22,47 @@ then
     then
         ENV="eos_production"
     else
-        echoerr
+        echoerr "Expected one of the following (dev|eosdev|prod|eosprod|develop|production) i.e 'setup.sh dev'"
         exit
     fi
-    #Get setup.sh directory since we could be running this script from a different location
+
+    # Get setup.sh directory since we could be running this script from a different location
     CWD="$(dirname "$0")"
     echo "\nConfiguring build for \033[1;33m"$ENV"\033[0m\n"
-    cp "$CWD/templates/config/$ENV.config.hpp" $CWD/include/config/config.hpp
+    cp "$CWD/templates/config/$ENV.config.hpp" "$CWD/include/config/config.hpp"
     mkdir -p build
+
+elif [[ $# -eq 2 ]];
+then
+    if [[ "$1" == "compiler" ]];
+    then
+        if [[ "$2" == "local" ]];
+        then
+            COMPILER="local"
+        elif [[ "$2" == "docker" ]];
+        then
+            COMPILER="docker"
+        else
+            echoerr "Expected 'local' or 'docker' as the second argument for mode 2."
+            exit
+        fi
+
+        # Get setup.sh directory since we could be running this script from a different location
+        CWD="$(dirname "$0")"
+        echo "\nConfiguring compiler for \033[1;33m"$COMPILER"\033[0m\n"
+
+        if [[ "$COMPILER" == "local" ]];
+        then
+            cp "$CWD/templates/cmake/CMakeLists.local.txt" "$CWD/CMakeLists.txt"
+            cp "$CWD/templates/cmake/CMakeLists_src.local.txt" "$CWD/src/CMakeLists.txt"
+        elif [[ "$COMPILER" == "docker" ]];
+        then
+            cp "$CWD/templates/cmake/CMakeLists.dune.txt" "$CWD/CMakeLists.txt"
+            cp "$CWD/templates/cmake/CMakeLists_src.dune.txt" "$CWD/src/CMakeLists.txt"
+        fi
+    else
+        echoerr "Expected 'compiler' as the first argument for mode 2."
+    fi
 else
-    echoerr
+    echoerr "Incorrect number of arguments."
 fi

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,10 +1,9 @@
 project(dao)
 
-set(EOSIO_WASM_OLD_BEHAVIOR "Off")
-find_package(eosio.cdt)
+find_package(cdt)
 
 # Activate Logging
-#add_compile_definitions(USE_LOGGING)
+# add_compile_definitions(USE_LOGGING)
 
 add_contract( dao dao
                 dao.cpp

--- a/templates/cmake/CMakeLists.dune.txt
+++ b/templates/cmake/CMakeLists.dune.txt
@@ -1,0 +1,21 @@
+project(dao)
+
+cmake_minimum_required(VERSION 3.16)
+
+include(ExternalProject)
+# if no cdt root is given use default path
+if(CDT_ROOT STREQUAL "" OR NOT CDT_ROOT)
+   find_package(cdt)
+endif()
+
+ExternalProject_Add(
+   dao_project
+   SOURCE_DIR ${CMAKE_SOURCE_DIR}/src
+   BINARY_DIR ${CMAKE_BINARY_DIR}/dao
+   CMAKE_ARGS -DCMAKE_TOOLCHAIN_FILE=${CDT_ROOT}/lib/cmake/cdt/CDTWasmToolchain.cmake
+   UPDATE_COMMAND ""
+   PATCH_COMMAND ""
+   TEST_COMMAND ""
+   INSTALL_COMMAND ""
+   BUILD_ALWAYS 1
+)

--- a/templates/cmake/CMakeLists.local.txt
+++ b/templates/cmake/CMakeLists.local.txt
@@ -1,0 +1,21 @@
+project(dao)
+
+cmake_minimum_required(VERSION 3.16)
+
+include(ExternalProject)
+# if no cdt root is given use default path
+if(EOSIO_CDT_ROOT STREQUAL "" OR NOT EOSIO_CDT_ROOT)
+   find_package(eosio.cdt)
+endif()
+
+ExternalProject_Add(
+   dao_project
+   SOURCE_DIR ${CMAKE_SOURCE_DIR}/src
+   BINARY_DIR ${CMAKE_BINARY_DIR}/dao
+   CMAKE_ARGS -DCMAKE_TOOLCHAIN_FILE=${EOSIO_CDT_ROOT}/lib/cmake/eosio.cdt/EosioWasmToolchain.cmake
+   UPDATE_COMMAND ""
+   PATCH_COMMAND ""
+   TEST_COMMAND ""
+   INSTALL_COMMAND ""
+   BUILD_ALWAYS 1
+)

--- a/templates/cmake/CMakeLists_src.dune.txt
+++ b/templates/cmake/CMakeLists_src.dune.txt
@@ -1,0 +1,73 @@
+project(dao)
+
+find_package(cdt)
+
+# Activate Logging
+# add_compile_definitions(USE_LOGGING)
+
+add_contract( dao dao
+                dao.cpp
+                typed_document.cpp
+                typed_document_factory.cpp
+                util.cpp
+                period.cpp
+                member.cpp
+                assignment.cpp
+                recurring_activity.cpp
+                time_share.cpp
+                settings.cpp
+                treasury/actions.cpp
+                treasury/balance.cpp
+                treasury/payment.cpp
+                treasury/redemption.cpp
+                treasury/treasury.cpp
+                pricing/actions.cpp
+                pricing/pricing_plan.cpp
+                pricing/price_offer.cpp
+                pricing/plan_manager.cpp
+                pricing/billing_info.cpp
+                pricing/features.cpp
+                payers/payer.cpp
+                payers/peg_payer.cpp
+                payers/voice_payer.cpp
+                payers/reward_payer.cpp
+                payers/payer_factory.cpp
+                proposals/proposal.cpp
+                proposals/role_proposal.cpp
+                proposals/badge_proposal.cpp
+                proposals/badge_assignment_proposal.cpp
+                proposals/ass_extend_proposal.cpp
+                proposals/assignment_proposal.cpp
+                proposals/payout_proposal.cpp
+                proposals/attestation_proposal.cpp
+                proposals/edit_proposal.cpp
+                proposals/suspend_proposal.cpp
+                proposals/quest_start_proposal.cpp
+                proposals/quest_completion_proposal.cpp
+                proposals/budget_proposal.cpp
+                proposals/policy_proposal.cpp
+                proposals/poll_proposal.cpp
+                proposals/circle_proposal.cpp
+                proposals/proposal_factory.cpp
+                ballots/vote.cpp
+                ballots/vote_tally.cpp
+                badges/badges.cpp
+                comments/likeable.cpp
+                comments/comment.cpp
+                comments/section.cpp
+                comments/reaction.cpp
+                upvote_election/actions.cpp
+                upvote_election/election_round.cpp
+                upvote_election/upvote_election.cpp
+                upvote_election/vote_group.cpp
+                ../document-graph/src/document_graph/document_graph.cpp
+                ../document-graph/src/document_graph/document.cpp
+                ../document-graph/src/document_graph/content_wrapper.cpp
+                ../document-graph/src/document_graph/content.cpp
+                ../document-graph/src/document_graph/edge.cpp
+                ../document-graph/src/document_graph/util.cpp
+                ../document-graph/src/logger/logger.cpp
+            )
+
+target_include_directories( dao PUBLIC ${CMAKE_SOURCE_DIR}/../include ${CMAKE_SOURCE_DIR}/../document-graph/include )
+target_ricardian_directory( dao ${CMAKE_SOURCE_DIR}/../ricardian )

--- a/templates/cmake/CMakeLists_src.local.txt
+++ b/templates/cmake/CMakeLists_src.local.txt
@@ -1,0 +1,74 @@
+project(dao)
+
+set(EOSIO_WASM_OLD_BEHAVIOR "Off")
+find_package(eosio.cdt)
+
+# Activate Logging
+#add_compile_definitions(USE_LOGGING)
+
+add_contract( dao dao
+                dao.cpp
+                typed_document.cpp
+                typed_document_factory.cpp
+                util.cpp
+                period.cpp
+                member.cpp
+                assignment.cpp
+                recurring_activity.cpp
+                time_share.cpp
+                settings.cpp
+                treasury/actions.cpp
+                treasury/balance.cpp
+                treasury/payment.cpp
+                treasury/redemption.cpp
+                treasury/treasury.cpp
+                pricing/actions.cpp
+                pricing/pricing_plan.cpp
+                pricing/price_offer.cpp
+                pricing/plan_manager.cpp
+                pricing/billing_info.cpp
+                pricing/features.cpp
+                payers/payer.cpp
+                payers/peg_payer.cpp
+                payers/voice_payer.cpp
+                payers/reward_payer.cpp
+                payers/payer_factory.cpp
+                proposals/proposal.cpp
+                proposals/role_proposal.cpp
+                proposals/badge_proposal.cpp
+                proposals/badge_assignment_proposal.cpp
+                proposals/ass_extend_proposal.cpp
+                proposals/assignment_proposal.cpp
+                proposals/payout_proposal.cpp
+                proposals/attestation_proposal.cpp
+                proposals/edit_proposal.cpp
+                proposals/suspend_proposal.cpp
+                proposals/quest_start_proposal.cpp
+                proposals/quest_completion_proposal.cpp
+                proposals/budget_proposal.cpp
+                proposals/policy_proposal.cpp
+                proposals/poll_proposal.cpp
+                proposals/circle_proposal.cpp
+                proposals/proposal_factory.cpp
+                ballots/vote.cpp
+                ballots/vote_tally.cpp
+                badges/badges.cpp
+                comments/likeable.cpp
+                comments/comment.cpp
+                comments/section.cpp
+                comments/reaction.cpp
+                upvote_election/actions.cpp
+                upvote_election/election_round.cpp
+                upvote_election/upvote_election.cpp
+                upvote_election/vote_group.cpp
+                ../document-graph/src/document_graph/document_graph.cpp
+                ../document-graph/src/document_graph/document.cpp
+                ../document-graph/src/document_graph/content_wrapper.cpp
+                ../document-graph/src/document_graph/content.cpp
+                ../document-graph/src/document_graph/edge.cpp
+                ../document-graph/src/document_graph/util.cpp
+                ../document-graph/src/logger/logger.cpp
+            )
+
+target_include_directories( dao PUBLIC ${CMAKE_SOURCE_DIR}/../include ${CMAKE_SOURCE_DIR}/../document-graph/include )
+target_ricardian_directory( dao ${CMAKE_SOURCE_DIR}/../ricardian )

--- a/util/README.md
+++ b/util/README.md
@@ -1,5 +1,12 @@
 ## DUNES scripts 
 
+All these scripts are to make building on a docker image easier.
+
+You should install DUNES for Antelope Leap 4.x:
+https://github.com/AntelopeIO/DUNES
+
+This installs the correct docker container.
+
 ## dunes_terminal
 
 Enter the docker container
@@ -17,3 +24,5 @@ This script runs cmake and ninja to build the conract
 ## Docker check_config.sh
 
 Check current build configuration
+
+## Docker optimize_wasm - runs wasm-opt

--- a/util/README.md
+++ b/util/README.md
@@ -1,0 +1,19 @@
+## DUNES scripts 
+
+## dunes_terminal
+
+Enter the docker container
+
+This script opens a bash shell onto the docker container
+
+## Docker: install_ninja.sh
+
+This script is to be run inside the docker container and installs the ninja build tool
+
+## Docker: run_make.sh
+
+This script runs cmake and ninja to build the conract
+
+## Docker check_config.sh
+
+Check current build configuration

--- a/util/check_config.sh
+++ b/util/check_config.sh
@@ -1,0 +1,5 @@
+cat ../include/config/config.hpp
+
+cat ../CMakeLists.txt | grep find_package
+
+cat ../src/CMakeLists.txt | grep find_package

--- a/util/dunes_terminal.sh
+++ b/util/dunes_terminal.sh
@@ -12,7 +12,4 @@ HOST_PARENT_DIR="/host$PARENT_DIR"
 echo "The absolute path of the script's directory is: $SCRIPT_DIR"
 echo "The parent directory path is: $PARENT_DIR"
 
-# docker exec -it dune_container bash -c "cd '$HOST_PARENT_DIR'; bash"
-# docker exec -it dune_container bash -c "PS1='$(printf "\033[0;33m\w\033[0m\n> ")'; cd '$HOST_PARENT_DIR'; bash"
-# docker exec -it dune_container bash -c "PS1='\[\033[0;33m\]\w\n> \[\033[0m\]'; cd '$HOST_PARENT_DIR'; bash"
 docker exec -it dune_container bash -c "cd '$HOST_PARENT_DIR'; PS1='\[\033[0;33m\]\w\n> \[\033[0m\]' bash"

--- a/util/dunes_terminal.sh
+++ b/util/dunes_terminal.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+# Get the absolute path of the directory where the script resides
+SCRIPT_DIR=$(dirname "$(readlink -f "$0")")
+
+# Get the absolute path of the parent directory (one level up) of SCRIPT_DIR
+PARENT_DIR=$(dirname "$SCRIPT_DIR")
+
+# Add the /host prefix to PARENT_DIR
+HOST_PARENT_DIR="/host$PARENT_DIR"
+
+echo "The absolute path of the script's directory is: $SCRIPT_DIR"
+echo "The parent directory path is: $PARENT_DIR"
+
+# docker exec -it dune_container bash -c "cd '$HOST_PARENT_DIR'; bash"
+# docker exec -it dune_container bash -c "PS1='$(printf "\033[0;33m\w\033[0m\n> ")'; cd '$HOST_PARENT_DIR'; bash"
+# docker exec -it dune_container bash -c "PS1='\[\033[0;33m\]\w\n> \[\033[0m\]'; cd '$HOST_PARENT_DIR'; bash"
+docker exec -it dune_container bash -c "cd '$HOST_PARENT_DIR'; PS1='\[\033[0;33m\]\w\n> \[\033[0m\]' bash"

--- a/util/install_ninja.sh
+++ b/util/install_ninja.sh
@@ -7,12 +7,6 @@ command_exists() {
   command -v "$1" >/dev/null 2>&1
 }
 
-# Check if Ninja is already installed
-if command_exists ninja; then
-  echo "Ninja is already installed."
-  exit 0
-fi
-
 # Check if required tools (git and cmake) are installed
 if ! command_exists git || ! command_exists cmake; then
   echo "Installing required dependencies: git and cmake..."
@@ -27,3 +21,8 @@ apt-get install -y ninja-build
 
 echo "Ninja installation complete."
 
+echo "Installing wasm-opt"
+
+apt-get install binaryen
+
+echo "wasm-opt install complete."

--- a/util/install_ninja.sh
+++ b/util/install_ninja.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+## Run this inside the docker container to install ninja
+
+# Function to check if a command is available
+command_exists() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+# Check if Ninja is already installed
+if command_exists ninja; then
+  echo "Ninja is already installed."
+  exit 0
+fi
+
+# Check if required tools (git and cmake) are installed
+if ! command_exists git || ! command_exists cmake; then
+  echo "Installing required dependencies: git and cmake..."
+  apt-get update
+  apt-get install -y git cmake
+fi
+
+# Install Ninja using apt-get
+echo "Installing Ninja..."
+apt-get install -y ninja-build
+
+
+echo "Ninja installation complete."
+

--- a/util/optimize_wasm.sh
+++ b/util/optimize_wasm.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Get the directory where the script is located
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
+
+# Set the build directory relative to the script directory
+BUILD_DIR="$SCRIPT_DIR/../build_ninja"
+
+echo "Running wasm-opt on $BUILD_DIR/dao/dao.wasm"
+
+wasm-opt -O3 -o "$BUILD_DIR/dao/dao_O3.wasm" "$BUILD_DIR/dao/dao.wasm"
+
+echo "Optimized wasm saved in $BUILD_DIR/dao/dao_O3.wasm"
+
+# Get the file sizes of dao.wasm and dao_O3.wasm in kilobytes
+original_size_kb=$(du -k "$BUILD_DIR/dao/dao.wasm" | cut -f1)
+optimized_size_kb=$(du -k "$BUILD_DIR/dao/dao_O3.wasm" | cut -f1)
+
+# Convert kilobytes to bytes
+original_size=$((original_size_kb * 1024))
+optimized_size=$((optimized_size_kb * 1024))
+
+echo "Original file size (dao.wasm): $original_size bytes"
+echo "Optimized file size (dao_O3.wasm): $optimized_size bytes"
+
+# Calculate and display the file size reduction percentage
+percentage=$(awk "BEGIN { pc=100*(${original_size}-${optimized_size})/${original_size}; i=int(pc); print (pc-i<0.5)?i:i+1 }")
+echo "File size reduced by $percentage%"

--- a/util/run_make.sh
+++ b/util/run_make.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# Function to check if a command is available
+command_exists() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+# Check if Ninja is installed
+if ! command_exists ninja; then
+  echo "Ninja is not installed. Please run the Ninja installation script first."
+  exit 1
+fi
+
+# Check if required tools (git, cmake) are installed
+if ! command_exists git || ! command_exists cmake; then
+  echo "Required dependencies (git and cmake) not found. Please install them first."
+  exit 1
+fi
+
+# Directory where the build will take place
+BUILD_DIR="build_ninja"
+
+# Create build directory if it doesn't exist
+mkdir -p "$BUILD_DIR"
+
+# Run CMake to generate Ninja Makefiles
+echo "Running CMake..."
+cmake -S . -B "$BUILD_DIR" -G Ninja
+
+# Change directory to build folder
+cd "$BUILD_DIR" || exit 1
+
+# Run Ninja to build the project
+echo "Running Ninja..."
+ninja
+
+# Optionally, you can run any tests or other commands here if needed.
+
+# Return to the original directory
+cd ..
+
+echo "Build complete."

--- a/util/set_contract.sh
+++ b/util/set_contract.sh
@@ -1,0 +1,1 @@
+cleos -u http://eos.greymass.com set contract dao.hypha ../build_ninja/dao dao_O3.wasm dao.abi


### PR DESCRIPTION
setup compiler local
and
setup compiler docker

The docker option copies CMakeLists files for DUNEs and the dune tool and Antelope Leap 4.x 

Many more utility scripts added - need to automate all of this, so we can just have a single command that

- pulls repo from GH
- configures for prod / compiler docker setup.sh prod setup.sh compiler docker
- installs ninja-build if needed
- runs cmake with ninja parameters: run_make.sh
cmake -S . -B "$BUILD_DIR" -G Ninja
- runs ninja to build the wasm
- installs wasm-opt if needed
- runs wasm-opt on dao.wasm
- has a simple deploy script to deploy on EOS mainnet (and others) - set_contract.sh
