### PR TITLE
Feature/compile flags for size

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,12 @@
-project(dao)
-
 cmake_minimum_required(VERSION 3.16)
 
+# Bypass compiler check - normal c++ can't handle eosio-cpp flags and fails
+set(CMAKE_CXX_COMPILER_WORKS 1)
+
+project(dao)
+
 include(ExternalProject)
+
 # if no cdt root is given use default path
 if(EOSIO_CDT_ROOT STREQUAL "" OR NOT EOSIO_CDT_ROOT)
    find_package(eosio.cdt)
@@ -19,3 +23,7 @@ ExternalProject_Add(
    INSTALL_COMMAND ""
    BUILD_ALWAYS 1
 )
+
+# Set eosio-cpp flags 
+set(CMAKE_CXX_FLAGS "-O=s --lto-opt=O3 --fmerge-all-constants")
+

--- a/deploy_dao.sh
+++ b/deploy_dao.sh
@@ -1,0 +1,4 @@
+cd build
+make -j10
+wasm-opt -O3 dao/dao.wasm -o dao/dao_O3.wasm
+cleos set contract dao.hypha dao dao_O3.wasm dao.abi

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,7 @@
 project(dao)
 
 set(EOSIO_WASM_OLD_BEHAVIOR "Off")
+
 find_package(eosio.cdt)
 
 # Activate Logging
@@ -72,3 +73,6 @@ add_contract( dao dao
 
 target_include_directories( dao PUBLIC ${CMAKE_SOURCE_DIR}/../include ${CMAKE_SOURCE_DIR}/../document-graph/include )
 target_ricardian_directory( dao ${CMAKE_SOURCE_DIR}/../ricardian )
+
+set(CMAKE_CXX_COMPILER_WORKS 1)
+set(CMAKE_CXX_FLAGS "-O=s --lto-opt=O3 --fmerge-all-constants")

--- a/templates/cmake/CMakeLists.dune.txt
+++ b/templates/cmake/CMakeLists.dune.txt
@@ -1,3 +1,8 @@
+cmake_minimum_required(VERSION 3.16)
+
+# Bypass compiler check - normal c++ can't handle eosio-cpp flags and fails
+set(CMAKE_CXX_COMPILER_WORKS 1)
+
 project(dao)
 
 cmake_minimum_required(VERSION 3.16)
@@ -19,3 +24,6 @@ ExternalProject_Add(
    INSTALL_COMMAND ""
    BUILD_ALWAYS 1
 )
+
+# Set eosio-cpp flags 
+set(CMAKE_CXX_FLAGS "-O=s --lto-opt=O3 --fmerge-all-constants")

--- a/templates/cmake/CMakeLists.local.txt
+++ b/templates/cmake/CMakeLists.local.txt
@@ -1,3 +1,8 @@
+cmake_minimum_required(VERSION 3.16)
+
+# Bypass compiler check - normal c++ can't handle eosio-cpp flags and fails
+set(CMAKE_CXX_COMPILER_WORKS 1)
+
 project(dao)
 
 cmake_minimum_required(VERSION 3.16)
@@ -19,3 +24,6 @@ ExternalProject_Add(
    INSTALL_COMMAND ""
    BUILD_ALWAYS 1
 )
+
+# Set eosio-cpp flags 
+set(CMAKE_CXX_FLAGS "-O=s --lto-opt=O3 --fmerge-all-constants")

--- a/templates/cmake/CMakeLists_src.dune.txt
+++ b/templates/cmake/CMakeLists_src.dune.txt
@@ -71,3 +71,6 @@ add_contract( dao dao
 
 target_include_directories( dao PUBLIC ${CMAKE_SOURCE_DIR}/../include ${CMAKE_SOURCE_DIR}/../document-graph/include )
 target_ricardian_directory( dao ${CMAKE_SOURCE_DIR}/../ricardian )
+
+set(CMAKE_CXX_COMPILER_WORKS 1)
+set(CMAKE_CXX_FLAGS "-O=s --lto-opt=O3 --fmerge-all-constants")

--- a/templates/cmake/CMakeLists_src.local.txt
+++ b/templates/cmake/CMakeLists_src.local.txt
@@ -72,3 +72,6 @@ add_contract( dao dao
 
 target_include_directories( dao PUBLIC ${CMAKE_SOURCE_DIR}/../include ${CMAKE_SOURCE_DIR}/../document-graph/include )
 target_ricardian_directory( dao ${CMAKE_SOURCE_DIR}/../ricardian )
+
+set(CMAKE_CXX_COMPILER_WORKS 1)
+set(CMAKE_CXX_FLAGS "-O=s --lto-opt=O3 --fmerge-all-constants")


### PR DESCRIPTION
This significantly reduces the size of the wasm file.

432Kb for the build with treasury features, instead of > 600

wasm opt gets it below 400. 

